### PR TITLE
Update codecov.yaml with new default rules

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,3 +1,9 @@
 flag_management:
   default_rules:
-    carryforward: false
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+      - type: patch
+        target: 90%

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,3 +1,8 @@
+coverage:
+  range: 60..80
+  round: down
+  precision: 2
+
 flag_management:
   default_rules:
     carryforward: true


### PR DESCRIPTION
This pull request updates the codecov.yaml file with new default rules for coverage. The coverage range is set to 60-80, with rounding down to 2 decimal places. Additionally, the flag_management section has been modified to enable carryforward and add new status rules for project and patch targets.