### PR TITLE
Update docker.yaml workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -139,8 +139,8 @@ jobs:
         continue-on-error: true
         uses: docker/scout-action@704685e6e6dc4462258fb11d36d3a14ca7bda1e6 # v1.1.0
         with:
-          command: cves${{ github.event_name == 'pull_request' && ',recommendations,compare' || '' }}
-          image: image://jkreileder/cf-ips-to-hcloud-fw:${{ steps.docker-meta.outputs.version }}
+          command: cves${{ !startsWith(github.ref, 'refs/tags/') && ',recommendations,compare' || '' }}
+          image: jkreileder/cf-ips-to-hcloud-fw:${{ steps.docker-meta.outputs.version }}
           sarif-file: sarif.output.json
           organization: jkreileder
           to: registry://jkreileder/cf-ips-to-hcloud-fw:1


### PR DESCRIPTION
This pull request updates the docker.yaml workflow file. It modifies the 'command' and 'image' properties in the 'docker/scout-action' step. The 'command' property now includes 'cves' and 'recommendations' if the event is not a tag. The 'image' property is updated to use 'jkreileder/cf-ips-to-hcloud-fw' instead of 'image://jkreileder/cf-ips-to-hcloud-fw'. The 'sarif-file', 'organization', and 'to' properties remain unchanged.