### PR TITLE
Implement error handling for unreadable configuration files or directories

### DIFF
--- a/src/cf_ips_to_hcloud_fw/__main__.py
+++ b/src/cf_ips_to_hcloud_fw/__main__.py
@@ -57,17 +57,21 @@ def read_config(config_file: str) -> list[Project]:
         with open(config_file, encoding="utf-8") as file:
             config = yaml.safe_load(file)
     except FileNotFoundError:
-        log_error_and_exit(f"Config file {config_file} not found.")
+        log_error_and_exit(f"Config file {config_file!r} not found.")
+    except IsADirectoryError:
+        log_error_and_exit(f"Config file {config_file!r} is a directory.")
+    except PermissionError:
+        log_error_and_exit(f"Config file {config_file!r} is unreadable.")
     except YAMLError as e:
-        log_error_and_exit(f"Error reading config file {config_file}: {e}")
+        log_error_and_exit(f"Error reading config file {config_file!r}: {e}")
 
     try:
         projects = TypeAdapter(list[Project]).validate_python(config)
     except ValidationError as e:
-        log_error_and_exit(f"Config file {config_file} is broken: {e}")
+        log_error_and_exit(f"Config file {config_file!r} is broken: {e}")
 
     if not projects:
-        logging.warning(f"Config file {config_file} contains no projects - exiting")
+        logging.warning(f"Config file {config_file!r} contains no projects - exiting")
         sys.exit(0)
 
     return projects

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,8 +47,33 @@ def test_read_config_file_not_found(
     assert e.type is SystemExit
     assert e.value.code == 1
     mock_open.assert_called_once_with("config.yaml", encoding="utf-8")
-    mock_logging.assert_called_once()
-    assert mock_logging.call_args[0][0].startswith("Config file config.yaml not found.")
+    mock_logging.assert_called_once_with("Config file 'config.yaml' not found.")
+
+
+@patch("builtins.open", side_effect=IsADirectoryError("config.yaml"))
+@patch("logging.error")
+def test_read_config_file_is_a_directory(
+    mock_logging: MagicMock, mock_open: MagicMock
+) -> None:
+    with pytest.raises(SystemExit) as e:
+        read_config("config.yaml")
+    assert e.type is SystemExit
+    assert e.value.code == 1
+    mock_open.assert_called_once_with("config.yaml", encoding="utf-8")
+    mock_logging.assert_called_once_with("Config file 'config.yaml' is a directory.")
+
+
+@patch("builtins.open", side_effect=PermissionError("config.yaml"))
+@patch("logging.error")
+def test_read_config_file_is_unreadable(
+    mock_logging: MagicMock, mock_open: MagicMock
+) -> None:
+    with pytest.raises(SystemExit) as e:
+        read_config("config.yaml")
+    assert e.type is SystemExit
+    assert e.value.code == 1
+    mock_open.assert_called_once_with("config.yaml", encoding="utf-8")
+    mock_logging.assert_called_once_with("Config file 'config.yaml' is unreadable.")
 
 
 @patch("builtins.open", mock_open())
@@ -59,7 +84,7 @@ def test_read_config_empty(mock_logging: MagicMock) -> None:
     assert e.type is SystemExit
     assert e.value.code == 1
     mock_logging.assert_called_once()
-    assert "Config file config.yaml is broken" in mock_logging.call_args[0][0]
+    assert "Config file 'config.yaml' is broken: " in mock_logging.call_args[0][0]
 
 
 @patch("builtins.open", mock_open(read_data="[]"))
@@ -70,7 +95,7 @@ def test_read_config_empty_list(mock_logging: MagicMock) -> None:
     assert e.type is SystemExit
     assert e.value.code == 0
     mock_logging.assert_called_once_with(
-        "Config file config.yaml contains no projects - exiting",
+        "Config file 'config.yaml' contains no projects - exiting",
     )
 
 
@@ -82,7 +107,7 @@ def test_read_config_broken_yaml(mock_logging: MagicMock) -> None:
     assert e.type is SystemExit
     assert e.value.code == 1
     mock_logging.assert_called_once()
-    assert "Error reading config file config.yaml" in mock_logging.call_args[0][0]
+    assert "Error reading config file 'config.yaml': " in mock_logging.call_args[0][0]
 
 
 @patch(


### PR DESCRIPTION
This pull request adds error handling to the `read_config` function to handle cases where the configuration file is a directory or is unreadable. It also includes corresponding unit tests for these scenarios.