### PR TITLE
Don't scan context and builder for sbom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # syntax = docker/dockerfile:1.6.0@sha256:ac85f380a63b13dfcefa89046420e1781752bab202122f8f50032edf31be0021
 
-ARG BUILDKIT_SBOM_SCAN_CONTEXT=true
-
-
 FROM --platform=$BUILDPLATFORM python:3.12.1-slim-bookworm@sha256:c805c5edcf6005fd72f933156f504525e1da263ffbc3fae6b4940e6c360c216f AS builder
-ARG BUILDKIT_SBOM_SCAN_STAGE=true
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This pull request removes the scanning of the context and builder for sbom, as it tends to confuse scanners.