### PR TITLE
Add objects.githubusercontent.com to allowed hosts

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -43,6 +43,7 @@ jobs:
             api.github.com:443
             files.pythonhosted.org:443
             github.com:443
+            objects.githubusercontent.com:443
             pypi.org:443
             uploads.github.com:443
 


### PR DESCRIPTION
This pull request adds objects.githubusercontent.com to the list of allowed hosts in the code. This change ensures that requests to objects.githubusercontent.com can be made securely.