### PR TITLE
Add test cases for command line arguments

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,6 +35,12 @@ def test_create_parser() -> None:
     assert "--debug" in parser._option_string_actions
     assert "-v" in parser._option_string_actions
     assert "--version" in parser._option_string_actions
+    args = parser.parse_args(["-c", "config.yaml", "-d"])
+    assert args.config == "config.yaml"
+    assert args.debug is True
+    args = parser.parse_args(["-c", "config2.yaml"])
+    assert args.config == "config2.yaml"
+    assert args.debug is False
 
 
 @patch("builtins.open", side_effect=FileNotFoundError("config.yaml"))

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,9 +2,20 @@ from __future__ import annotations
 
 import re
 
+import pytest
+
+from cf_ips_to_hcloud_fw.__main__ import create_parser
 from cf_ips_to_hcloud_fw.version import __VERSION__
 
 
-def test_version() -> None:
+def test_version(capfd: pytest.CaptureFixture[str]) -> None:
     assert isinstance(__VERSION__, str)
     assert re.match(r"^\d+\.\d+\.\d+(-dev)?$", __VERSION__)
+
+    parser = create_parser()
+    with pytest.raises(SystemExit) as e:
+        parser.parse_args(["-v"])
+    assert e.type is SystemExit
+    assert e.value.code == 0
+    out, _err = capfd.readouterr()
+    assert out.strip() == __VERSION__


### PR DESCRIPTION
This pull request adds test cases for command line arguments in the `test_main.py` and `test_version.py` files.