### PR TITLE
Add SLSA3 workflows for Docker images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -24,6 +24,8 @@ jobs:
       id-token: write
       security-events: write
       pull-requests: write
+    outputs:
+      digest: ${{ steps.build-and-push.outputs.digest }}
 
     steps:
       - name: Harden runner
@@ -168,3 +170,60 @@ jobs:
         continue-on-error: true
         with:
           sarif_file: ${{ steps.grype-scan.outputs.sarif }}
+
+  provenance-docker:
+    name: Generate SLSA Provenance for DockerHub
+    if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+    needs:
+      - docker
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    # Can't pin with hash due to how this workflow works.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.0
+    with:
+      image: jkreileder/cf-ips-to-hcloud-fw
+      digest: ${{ needs.docker.outputs.digest }}
+      private-repository: true
+    secrets:
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  provenance-quay:
+    name: Generate SLSA Provenance for Quay
+    if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+    needs:
+      - docker
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    # Can't pin with hash due to how this workflow works.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.0
+    with:
+      image: quay.io/jkreileder/cf-ips-to-hcloud-fw
+      digest: ${{ needs.docker.outputs.digest }}
+      private-repository: true
+    secrets:
+      registry-username: ${{ secrets.QUAY_USERNAME }}
+      registry-password: ${{ secrets.QUAY_TOKEN }}
+
+  provenance-ghcr:
+    name: Generate SLSA Provenance for GitHub Container Registry
+    if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+    needs:
+      - docker
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    # Can't pin with hash due to how this workflow works.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.0
+    with:
+      image: ghcr.io/jkreileder/cf-ips-to-hcloud-fw
+      digest: ${{ needs.docker.outputs.digest }}
+      private-repository: true
+    secrets:
+      registry-username: ${{ github.repository_owner }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds SLSA3 workflows for Docker images. It includes the necessary steps to generate SLSA Provenance for DockerHub, Quay, and GitHub Container Registry. The workflows ensure that the images have a secure supply chain and can be trusted.