### PR TITLE
Add CPython implementation to classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Internet",
     "Topic :: System :: Networking :: Firewalls",
     "Topic :: Utilities",


### PR DESCRIPTION
This pull request adds the CPython implementation to the classifiers list in the code. This change ensures that the code is compatible with CPython and can be used with Python versions 3.9, 3.10, 3.11, and 3.12.