### PR TITLE
Prepare v1.0.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what actually happened.
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - cf-ips-to-hcloud-fw version: [e.g. 1.0.6]
+ - cf-ips-to-hcloud-fw version: [e.g. 1.0.7]
  - Deployment method: [e.g. Docker, Python module]
  - If Python module, Python Version: [e.g. 3.12]
  - If Python module, OS: [e.g. MacOS 14.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,36 @@
 # Changelog
 
-## [v1.0.7] - unreleased
+## [v1.0.7] - 2024-01-20
 
 ### Added
 
+- Check passed arguments in test_main (#74)
+- Add CPython implementation to classifiers (#61)
+- Pin pre-commit hook versions (#59)
+- Update Kubernetes CronJob API version (#54)
+- Add SLSA3 workflows for Docker images (#50)
+
 ### Changed
 
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
+- Update base image shas (#73)
+- Bump ruff from 0.1.13 to 0.1.14 (#72)
+- Update pyyaml hashes (#71)
+- Bump docker/scout-action from 1.2.2 to 1.3.0 (#67)
+- Bump python from `ee9a59c` to `247e70c` (#70)
+- Bump actions/dependency-review-action from 3.1.5 to 4.0.0 (#68)
+- Bump anchore/scan-action from 3.5.0 to 3.6.0 (#69)
+- Bump actions/upload-artifact from 4.1.0 to 4.2.0 (#66)
+- Bump github/codeql-action from 3.23.0 to 3.23.1 (#65)
+- Refactor: Modularize Cloudflare, hcloud firewall, config and logging functionality into separate modules (#64)
+- Update pyright to version 1.1.347 (#63)
+- Update pyright to version 1.1.346 (#62)
+- Bump actions/upload-artifact from 4.0.0 to 4.1.0 (#60)
+- Bump ruff from 0.1.12 to 0.1.13 (#58)
+- Bump ruff from 0.1.11 to 0.1.12 (#57)
+- Bump python from `c805c5e` to `ee9a59c` (#55)
+- Bump actions/download-artifact from 4.1.0 to 4.1.1 (#53)
+- Bump github/codeql-action from 3.22.12 to 3.23.0 (#52)
+- Bump anchore/scan-action from 3.4.0 to 3.5.0 (#51)
 
 ## [1.0.6] - 2024-01-08
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.0.6
+  jkreileder/cf-ips-to-hcloud-fw:1.0.7
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -122,7 +122,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.0`: This tag always points to the latest `1.0.x` release.
-- `1.0.6`: This tag points to the specific `1.0.6` release.
+- `1.0.7`: This tag points to the specific `1.0.7` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -171,7 +171,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.0.6
+              image: jkreileder/cf-ips-to-hcloud-fw:1.0.7
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false

--- a/src/cf_ips_to_hcloud_fw/version.py
+++ b/src/cf_ips_to_hcloud_fw/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__VERSION__ = "1.0.7-dev"
+__VERSION__ = "1.0.7"


### PR DESCRIPTION
This pull request prepares version 1.0.7 of the cf-ips-to-hcloud-fw software. It includes various changes and updates, such as checking passed arguments in test_main, adding CPython implementation to classifiers, updating base image shas, and bumping various dependencies.