### PR TITLE
Add cli.codecov.io to allowed endpoints

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -52,6 +52,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            cli.codecov.io:443
             codecov.io:443
             files.pythonhosted.org:443
             github.com:443


### PR DESCRIPTION
This pull request adds `cli.codecov.io` to the list of allowed endpoints in the GitHub Actions workflow file. This change ensures that the CLI for Codecov is able to communicate with the necessary endpoint for code coverage reporting.