### PR TITLE
Add CODECOV_TOKEN to Codecov action

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -93,6 +93,7 @@ jobs:
         with:
           files: ./coverage.xml
           flags: python-${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build
         run: make build

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -51,6 +51,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.codecov.io:443
             api.github.com:443
             cli.codecov.io:443
             codecov.io:443


### PR DESCRIPTION
This pull request adds the CODECOV_TOKEN to the Codecov action in order to enable code coverage reporting.