### PR TITLE
Bump version to 1.0.9-dev

### DIFF
--- a/src/cf_ips_to_hcloud_fw/version.py
+++ b/src/cf_ips_to_hcloud_fw/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__VERSION__ = "1.0.8"
+__VERSION__ = "1.0.9-dev"


### PR DESCRIPTION
Prepare for new development iteration by incrementing the project version to 1.0.9-dev, post-release of version 1.0.8. This separates the ongoing development work from the stable release.