### PR TITLE
Bump pytest from 8.0.0 to 8.0.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -110,9 +110,9 @@ pyright==1.1.350 \
     --hash=sha256:a8ba676de3a3737ea4d8590604da548d4498cc5ee9ee00b1a403c6db987916c6 \
     --hash=sha256:f1dde6bcefd3c90aedbe9dd1c573e4c1ddbca8c74bf4fa664dd3b1a599ac9a66
     # via -r requirements-dev.in
-pytest==8.0.0 \
-    --hash=sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c \
-    --hash=sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6
+pytest==8.0.1 \
+    --hash=sha256:267f6563751877d772019b13aacbe4e860d73fe8f651f28112e9ac37de7513ae \
+    --hash=sha256:3e4f16fe1c0a9dc9d9389161c127c3edc5d810c38d6793042fb81d9f48a59fca
     # via
     #   -r requirements-dev.in
     #   pytest-cov


### PR DESCRIPTION
This pull request updates pytest from version 8.0.0 to 8.0.1.