### PR TITLE
Bump urllib3 from 2.2.0 to 2.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -283,7 +283,7 @@ typing-extensions==4.9.0 \
     # via
     #   pydantic
     #   pydantic-core
-urllib3==2.2.0 \
-    --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20 \
-    --hash=sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224
+urllib3==2.2.1 \
+    --hash=sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d \
+    --hash=sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19
     # via requests


### PR DESCRIPTION
This pull request updates the urllib3 library from version 2.2.0 to version 2.2.1. The update includes security fixes and improvements.