### PR TITLE
Optimize 'coverage' dependency comments

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -67,9 +67,7 @@ coverage[toml]==7.4.3 \
     --hash=sha256:f6a09b360d67e589236a44f0c39218a8efba2593b6abdccc300a8862cffc2f94 \
     --hash=sha256:fcc66e222cf4c719fe7722a403888b1f5e1682d1679bd780e2b26c18bb648cdc \
     --hash=sha256:fd6545d97c98a192c5ac995d21c894b581f1fd14cf389be90724d21808b657e2
-    # via
-    #   coverage
-    #   pytest-cov
+    # via pytest-cov
 exceptiongroup==1.2.0 \
     --hash=sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14 \
     --hash=sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68


### PR DESCRIPTION
Cleans up the 'requirements-dev.txt' by attributing 'coverage' only through 'pytest-cov,' reducing clutter and reflecting the streamlined dependency graph.