### PR TITLE
Bump ruff-pre-commit from 0.2.2 to 0.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: cc575a3e5800b42ffbb5182b53d87203b2c4fc26  # frozen: v0.2.2
+    rev: 0dd3437ad984b107802b242c696edf2bd72676ee  # frozen: v0.3.0
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
This pull request updates the ruff-pre-commit package from version 0.2.2 to version 0.3.0. The update includes bug fixes and improvements.