### PR TITLE
Bump pip-tools from 7.4.0 to 7.4.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -90,9 +90,9 @@ packaging==23.2 \
     # via
     #   build
     #   pytest
-pip-tools==7.4.0 \
-    --hash=sha256:a92a6ddfa86ff389fe6ace381d463bc436e2c705bd71d52117c25af5ce867bb7 \
-    --hash=sha256:b67432fd0759ed834c5367f9e0ce8c95441acecfec9c8e24b41aca166757adf0
+pip-tools==7.4.1 \
+    --hash=sha256:4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9 \
+    --hash=sha256:864826f5073864450e24dbeeb85ce3920cdfb09848a3d69ebf537b521f14bcc9
     # via -r requirements-dev.in
 pluggy==1.4.0 \
     --hash=sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981 \


### PR DESCRIPTION
This pull request updates the pip-tools package from version 7.4.0 to 7.4.1. The new version includes updated hashes for improved security.