### PR TITLE
Bump pytest from 8.0.2 to 8.1.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -108,9 +108,9 @@ pyright==1.1.353 \
     --hash=sha256:24343bbc2a4f997563f966b6244a2e863473f1d85af6d24abcb366fcbb4abca9 \
     --hash=sha256:8d7e6719d0be4fd9f4a37f010237c6a74d91ec1e7c81de634c2f3f9965f8ab43
     # via -r requirements-dev.in
-pytest==8.0.2 \
-    --hash=sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd \
-    --hash=sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096
+pytest==8.1.1 \
+    --hash=sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7 \
+    --hash=sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044
     # via
     #   -r requirements-dev.in
     #   pytest-cov


### PR DESCRIPTION
This pull request updates the pytest version from 8.0.2 to 8.1.1. The update includes changes to the pytest package, which are necessary for the project.