### PR TITLE
Bump wheel from 0.42.0 to 0.43.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -146,9 +146,9 @@ tomli==2.0.1 \
     #   pip-tools
     #   pyproject-hooks
     #   pytest
-wheel==0.42.0 \
-    --hash=sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d \
-    --hash=sha256:c45be39f7882c9d34243236f2d63cbd58039e360f85d0913425fbd7ceea617a8
+wheel==0.43.0 \
+    --hash=sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85 \
+    --hash=sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81
     # via pip-tools
 zipp==3.17.0 \
     --hash=sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31 \


### PR DESCRIPTION
This pull request updates the wheel package from version 0.42.0 to 0.43.0. The new version includes updated hashes for improved security.