### PR TITLE
Bump pyright from 1.1.353 to 1.1.354

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -104,9 +104,9 @@ pyproject-hooks==1.0.0 \
     # via
     #   build
     #   pip-tools
-pyright==1.1.353 \
-    --hash=sha256:24343bbc2a4f997563f966b6244a2e863473f1d85af6d24abcb366fcbb4abca9 \
-    --hash=sha256:8d7e6719d0be4fd9f4a37f010237c6a74d91ec1e7c81de634c2f3f9965f8ab43
+pyright==1.1.354 \
+    --hash=sha256:b1070dc774ff2e79eb0523fe87f4ba9a90550de7e4b030a2bc9e031864029a1f \
+    --hash=sha256:f28d61ae8ae035fc52ded1070e8d9e786051a26a4127bbd7a4ba0399b81b37b5
     # via -r requirements-dev.in
 pytest==8.1.1 \
     --hash=sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7 \


### PR DESCRIPTION
This pull request updates the pyright package from version 1.1.353 to version 1.1.354. The update includes bug fixes and improvements.