### PR TITLE
Bump docker/scout-sbom-indexer from 1.5.1 to 1.5.2

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -120,7 +120,7 @@ jobs:
           pull: true
           push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
           load: ${{ github.event_name == 'pull_request' || github.actor == 'dependabot[bot]' }}
-          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.5.1@sha256:aded850ddfef33fb06c76853b842351beccaf9387e4e67d39411c948330a6fe8' || '' }}
+          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.5.2@sha256:3e086e8acd5313193dfc01715438078fd909c2d55c6b5455499885959b9fd3c1' || '' }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}


### PR DESCRIPTION
This pull request updates the version of docker/scout-sbom-indexer from 1.5.1 to 1.5.2. The new version includes bug fixes and improvements.