### PR TITLE
Update Python base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=target=src/cf_ips_to_hcloud_fw,source=/src/cf_ips_to_hcloud_fw \
 EOF
 
 
-FROM python:3.12.2-alpine3.19@sha256:1a0501213b470de000d8432b3caab9d8de5489e9443c2cc7ccaa6b0aa5c3148e AS final-image
+FROM python:3.12.2-alpine3.19@sha256:25a82f6f8b720a6a257d58e478a0a5517448006e010c85273f4d9c706819478c AS final-image
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This pull request updates the Python base image in the Dockerfile to version 3.12.2-alpine3.19. This ensures that the latest version of Python is used in the project.