### PR TITLE
Prepare v1.0.9

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what actually happened.
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - cf-ips-to-hcloud-fw version: [e.g. 1.0.8]
+ - cf-ips-to-hcloud-fw version: [e.g. 1.0.9]
  - Deployment method: [e.g. Docker, Python module]
  - If Python module, Python Version: [e.g. 3.12]
  - If Python module, OS: [e.g. MacOS 14.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v1.0.9] - 2024-03-16
+
+### Added
+
+- Pin sbom-generator to specific version and hash (#132)
+- Optimize dependency hash regeneration (#123)
+
+### Changed
+
+- Update Python base image in Dockerfile (#193, #122)
+- Bump various dependencies and actions (Refer to commit history for detailed list)
+- Remove unneeded gdbm dependency with GPL-3.0 license (#131)
+- Move constraint spec from pip-compile invocation to requirements-dev.in (#133)
+
 ## [v1.0.8] - 2024-02-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.0.8
+  jkreileder/cf-ips-to-hcloud-fw:1.0.9
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -122,7 +122,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.0`: This tag always points to the latest `1.0.x` release.
-- `1.0.8`: This tag points to the specific `1.0.8` release.
+- `1.0.9`: This tag points to the specific `1.0.9` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -171,7 +171,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.0.8
+              image: jkreileder/cf-ips-to-hcloud-fw:1.0.9
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false

--- a/src/cf_ips_to_hcloud_fw/version.py
+++ b/src/cf_ips_to_hcloud_fw/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__VERSION__ = "1.0.9-dev"
+__VERSION__ = "1.0.9"


### PR DESCRIPTION
This pull request prepares version 1.0.9 of the cf-ips-to-hcloud-fw software. It includes various changes such as pinning sbom-generator to a specific version and hash, optimizing dependency hash regeneration, updating the Python base image in the Dockerfile, bumping various dependencies and actions, removing an unneeded gdbm dependency with GPL-3.0 license, and moving the constraint spec from pip-compile invocation to requirements-dev.in.