### PR TITLE
Bump pyright from 1.1.354 to 1.1.355

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -104,9 +104,9 @@ pyproject-hooks==1.0.0 \
     # via
     #   build
     #   pip-tools
-pyright==1.1.354 \
-    --hash=sha256:b1070dc774ff2e79eb0523fe87f4ba9a90550de7e4b030a2bc9e031864029a1f \
-    --hash=sha256:f28d61ae8ae035fc52ded1070e8d9e786051a26a4127bbd7a4ba0399b81b37b5
+pyright==1.1.355 \
+    --hash=sha256:bf30b6728fd68ae7d09c98292b67152858dd89738569836896df786e52b5fe48 \
+    --hash=sha256:dca4104cd53d6484e6b1b50b7a239ad2d16d2ffd20030bcf3111b56f44c263bf
     # via -r requirements-dev.in
 pytest==8.1.1 \
     --hash=sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7 \


### PR DESCRIPTION
This pull request updates the pyright package from version 1.1.354 to 1.1.355. The update includes bug fixes and improvements.