### PR TITLE
Bump slsa-github-generator from v1.9.1 to v1.10.0

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -141,7 +141,7 @@ jobs:
         if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]' }}
         id: docker-scout-cves
         continue-on-error: true
-        uses: docker/scout-action@b3dd3d6c420903eb3ff2812ac1b1d146ffb93a41 # v1.5.1
+        uses: docker/scout-action@b3dd3d6c420903eb3ff2812ac1b1d146ffb93a41 # v1.6.1
         with:
           command: cves${{ !startsWith(github.ref, 'refs/tags/') && ',recommendations,compare' || '' }}
           image: jkreileder/cf-ips-to-hcloud-fw:${{ steps.docker-meta.outputs.version }}
@@ -181,7 +181,7 @@ jobs:
       id-token: write
       packages: write
     # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.1
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with:
       image: jkreileder/cf-ips-to-hcloud-fw
       digest: ${{ needs.docker.outputs.digest }}
@@ -200,7 +200,7 @@ jobs:
       id-token: write
       packages: write
     # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.1
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with:
       image: quay.io/jkreileder/cf-ips-to-hcloud-fw
       digest: ${{ needs.docker.outputs.digest }}
@@ -219,7 +219,7 @@ jobs:
       id-token: write
       packages: write
     # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.1
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
     with:
       image: ghcr.io/jkreileder/cf-ips-to-hcloud-fw
       digest: ${{ needs.docker.outputs.digest }}

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -122,7 +122,7 @@ jobs:
       id-token: write
       contents: write
     # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.1
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
     with:
       base64-subjects: ${{ needs.build.outputs.hashes }}
       upload-assets: true


### PR DESCRIPTION
Signed-off-by: Jürgen Kreileder <jk@blackdown.de>