### PR TITLE
Allow api.deps.dev in egress policy

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -24,6 +24,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
             github.com:443
 


### PR DESCRIPTION
This pull request adds the `api.deps.dev` endpoint to the allowed endpoints in the egress policy, allowing outbound connections to `api.deps.dev:443`.