### PR TITLE
Bump docker/scout-action to v1.6.2

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -141,7 +141,7 @@ jobs:
         if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]' }}
         id: docker-scout-cves
         continue-on-error: true
-        uses: docker/scout-action@b3dd3d6c420903eb3ff2812ac1b1d146ffb93a41 # v1.6.1
+        uses: docker/scout-action@17b373594a388fbda8cdad7e6936c7fab42c4dd0 # v1.6.2
         with:
           command: cves${{ !startsWith(github.ref, 'refs/tags/') && ',recommendations,compare' || '' }}
           image: jkreileder/cf-ips-to-hcloud-fw:${{ steps.docker-meta.outputs.version }}


### PR DESCRIPTION
This pull request updates the docker/scout-action dependency to version 1.6.2. This update includes bug fixes and improvements.