### PR TITLE
Upgrade docker/scout-sbom-indexer to version 1.6.2

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -120,7 +120,7 @@ jobs:
           pull: true
           push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
           load: ${{ github.event_name == 'pull_request' || github.actor == 'dependabot[bot]' }}
-          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.6.0@sha256:093de035a0ffe98ccae4b0eba86c55e1bd2865a94ac8678abde3964f8c77c6ea' || '' }}
+          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.6.2@sha256:ff5f453c1964ace728475a65365288da52cd8c2e56e16b70251f85683d1ce05b' || '' }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}


### PR DESCRIPTION
Upgraded the Software Bill of Materials (SBOM) generator version from 1.6.0 to 1.6.2 in our Docker workflow configuration. This change ensures that our container images are generated with the latest security and feature enhancements provided by the updated SBOM indexing tool, reducing potential vulnerabilities and improving audit capabilities.

Signed-off-by: Jürgen Kreileder <jk@blackdown.de>