### PR TITLE
Bump pytest-cov from 4.1.0 to 5.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -114,9 +114,9 @@ pytest==8.1.1 \
     # via
     #   -r requirements-dev.in
     #   pytest-cov
-pytest-cov==4.1.0 \
-    --hash=sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6 \
-    --hash=sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a
+pytest-cov==5.0.0 \
+    --hash=sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652 \
+    --hash=sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857
     # via -r requirements-dev.in
 ruff==0.3.4 \
     --hash=sha256:3f3860057590e810c7ffea75669bdc6927bfd91e29b4baa9258fd48b540a4365 \


### PR DESCRIPTION
This pull request updates the pytest-cov dependency from version 4.1.0 to 5.0.0. The new version includes bug fixes and improvements.