### PR TITLE
Allow api.securityscorecards.dev in egress policy

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -26,6 +26,7 @@ jobs:
           allowed-endpoints: >
             api.deps.dev:443
             api.github.com:443
+            api.securityscorecards.dev:443
             github.com:443
 
       - name: "Checkout Repository"


### PR DESCRIPTION
This pull request adds the necessary configuration to allow outbound connections to api.securityscorecards.dev in the egress policy.