### PR TITLE
Update Python base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=target=src/cf_ips_to_hcloud_fw,source=/src/cf_ips_to_hcloud_fw \
 EOF
 
 
-FROM python:3.12.2-alpine3.19@sha256:c7eb5c92b7933fe52f224a91a1ced27b91840ac9c69c58bef40d602156bcdb41 AS final-image
+FROM python:3.12.2-alpine3.19@sha256:25a82f6f8b720a6a257d58e478a0a5517448006e010c85273f4d9c706819478c AS final-image
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This pull request updates the Python base image in the Dockerfile to version 3.12.2-alpine3.19. This ensures that the latest version of the Python base image is used, which may include bug fixes and security updates.