### PR TITLE
Remove CODECOV_TOKEN and support OIDC authentication

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -94,7 +94,6 @@ jobs:
         with:
           files: ./coverage.xml
           flags: python-${{ matrix.python-version }}
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build
         run: make build


### PR DESCRIPTION
The CODECOV_TOKEN was removed from the build job, and OIDC authentication was re-enabled.