### PR TITLE
Bump ruff from 0.3.5 to 0.3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 0ccbb5b7942d83fbcf7cb5e0fd99633efd2351d7  # frozen: v0.3.5
+    rev: e76e45000a5aa92cd2ec4d3fb1485f2f9fea5097  # frozen: v0.3.7
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
This pull request updates the ruff package from version 0.3.5 to version 0.3.7. The update includes bug fixes and improvements.