### PR TITLE
Bump docker/scout-sbom-indexer from 1.7.0 to 1.7.1

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -120,7 +120,7 @@ jobs:
           pull: true
           push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
           load: ${{ github.event_name == 'pull_request' || github.actor == 'dependabot[bot]' }}
-          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.7.0@sha256:2ae0f41dfddcab7acc4e7ac28fad60913fcae9ae3198163f9a85db2d74d093da' || '' }}
+          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.7.1@sha256:77da3d79606158e53bbf61b7503a1086ec1fe4e728cfa77293185e117b3f3c3a' || '' }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}


### PR DESCRIPTION
This pull request updates the version of docker/scout-sbom-indexer from 1.7.0 to 1.7.1. The new version includes bug fixes and improvements.