### PR TITLE
Bump ruff from 0.3.7 to 0.4.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: e76e45000a5aa92cd2ec4d3fb1485f2f9fea5097  # frozen: v0.3.7
+    rev: 2ca3d774ce61288db69efaea35298f70653dbcd3  # frozen: v0.4.0
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
This pull request updates the ruff dependency from version 0.3.7 to version 0.4.0. The update includes bug fixes and improvements.