### PR TITLE
Bump pyproject-hooks from 1.0.0 to 1.1.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -98,9 +98,9 @@ pluggy==1.5.0 \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \
     --hash=sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
     # via pytest
-pyproject-hooks==1.0.0 \
-    --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
-    --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5
+pyproject-hooks==1.1.0 \
+    --hash=sha256:4b37730834edbd6bd37f26ece6b44802fb1c1ee2ece0e54ddff8bfc06db86965 \
+    --hash=sha256:7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2
     # via
     #   build
     #   pip-tools
@@ -144,7 +144,6 @@ tomli==2.0.1 \
     #   build
     #   coverage
     #   pip-tools
-    #   pyproject-hooks
     #   pytest
 wheel==0.43.0 \
     --hash=sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85 \


### PR DESCRIPTION
This pull request updates the pyproject-hooks package from version 1.0.0 to 1.1.0. The new version includes bug fixes and improvements. This update is necessary to ensure compatibility with other dependencies and to take advantage of the latest features and enhancements.