### PR TITLE
Bump docker/dockerfile from 1.7.0 to 1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.7.0@sha256:dbbd5e059e8a07ff7ea6233b213b36aa516b4c53c645f1817a4dd18b83cbea56
+# syntax = docker/dockerfile:1.7.1@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
 
 FROM --platform=$BUILDPLATFORM python:3.12.3-slim-bookworm@sha256:2be8daddbb82756f7d1f2c7ece706aadcb284bf6ab6d769ea695cc3ed6016743 AS builder
 


### PR DESCRIPTION
This pull request updates the version of docker/dockerfile from 1.7.0 to 1.7.1. The change includes a syntax update in the Dockerfile, using the new version's SHA256 hash. This update ensures that the Dockerfile is compatible with the latest version of docker/dockerfile.