### PR TITLE
Move SBOM generation after build

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -81,13 +81,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
-      - name: Generate SBOM
-        if: ${{ matrix.python-version == '3.11' }}
-        uses: anchore/sbom-action@7ccf588e3cf3cc2611714c2eeae48550fbc17552 # v0.15.11
-        with:
-          format: spdx-json
-          output-file: sbom.spdx.json
-
       - name: Make venv
         run: make venv
 
@@ -113,6 +106,13 @@ jobs:
 
       - name: Build
         run: make build
+
+      - name: Generate SBOM
+        if: ${{ matrix.python-version == '3.11' }}
+        uses: anchore/sbom-action@7ccf588e3cf3cc2611714c2eeae48550fbc17552 # v0.15.11
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
 
       - name: Generate SBOM attestation
         if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && matrix.python-version == '3.11' }}


### PR DESCRIPTION
This PR moves the Software Bill of Materials (SBOM) generation step to occur after the build process in the GitHub Actions workflow for Python packages. This change ensures that the SBOM accurately reflects the state of the software after it is built, rather than before, capturing any dependencies or changes that occur during the build process. This adjustment aligns the SBOM generation with best practices for accurate software composition analysis.