### PR TITLE
Enhance Docker workflow security settings

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
             api.dso.docker.com:443
             api.github.com:443
@@ -48,6 +48,7 @@ jobs:
             index.docker.io:443
             nodejs.org:443
             objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
             pypi.org:443
             quay.io:443


### PR DESCRIPTION
This pull request tightens the security settings in the GitHub Actions Docker workflow. The egress policy has been changed from 'audit' to 'block' to ensure stricter outbound network traffic control. Additionally, the list of allowed endpoints has been expanded to include 'pkg-containers.githubusercontent.com:443', allowing access to necessary resources while maintaining security. These changes aim to minimize potential vulnerabilities and ensure compliance with security best practices.