### PR TITLE
Rename SBOM output files for clarity

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -133,7 +133,8 @@ jobs:
         with:
           image: ${{ vars.DOCKERHUB_USERNAME }}/cf-ips-to-hcloud-fw
           format: spdx-json
-          output-file: sbom.spdx.json
+          artifact-name: sbom-docker.spdx.json
+          output-file: sbom-docker.spdx.json
 
       - name: Generate SBOM attestation for DockerHub
         if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
@@ -141,7 +142,7 @@ jobs:
         with:
           subject-name: index.docker.io/${{ vars.DOCKERHUB_USERNAME }}/cf-ips-to-hcloud-fw
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          sbom-path: sbom.spdx.json
+          sbom-path: sbom-docker.spdx.json
           push-to-registry: true
 
       - name: Generate SBOM attestation for Quay
@@ -150,7 +151,7 @@ jobs:
         with:
           subject-name: quay.io/${{ vars.QUAY_USERNAME }}/cf-ips-to-hcloud-fw
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          sbom-path: sbom.spdx.json
+          sbom-path: sbom-docker.spdx.json
           push-to-registry: true
 
       - name: Generate SBOM attestation for GitHub Container Registry
@@ -159,7 +160,7 @@ jobs:
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/cf-ips-to-hcloud-fw
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          sbom-path: sbom.spdx.json
+          sbom-path: sbom-docker.spdx.json
           push-to-registry: true
 
       - name: Generate artifact attestation for DockerHub

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -112,14 +112,15 @@ jobs:
         uses: anchore/sbom-action@7ccf588e3cf3cc2611714c2eeae48550fbc17552 # v0.15.11
         with:
           format: spdx-json
-          output-file: sbom.spdx.json
+          artifact-name: sbom-python.spdx.json
+          output-file: sbom-python.spdx.json
 
       - name: Generate SBOM attestation
         if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && matrix.python-version == '3.11' }}
         uses: actions/attest-sbom@7d87da1e33596bc5503e50993d8f68c7a9bdfb4d # v1.1.0
         with:
           subject-path: dist/*.whl
-          sbom-path: sbom.spdx.json
+          sbom-path: sbom-python.spdx.json
 
       - name: Generate artifact attestation
         if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && matrix.python-version == '3.11' }}


### PR DESCRIPTION
To improve the organization and traceability of SBOM files, this PR renames the output files for Docker and Python package-related SBOMs. Docker-related SBOMs will now be named `sbom-docker.spdx.json`, while Python package-related SBOMs will be named `sbom-python.spdx.json`. This change ensures a clear distinction between the two types of SBOMs and enhances the identification and management of artifacts within CI/CD pipelines. Additionally, the SBOM attestation steps have been adjusted to align with the new file names, ensuring consistency in the build and deployment workflows.