### PR TITLE
Tighten egress policies for PyPi releases

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -174,7 +174,9 @@ jobs:
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            test.pypi.org:443
 
       - name: Download all the distribution packages
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
@@ -205,7 +207,9 @@ jobs:
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            upload.pypi.org:443
 
       - name: Download all the distribution packages
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
@@ -230,7 +234,10 @@ jobs:
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            uploads.github.com:443
 
       - name: Download all the distribution packages
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7


### PR DESCRIPTION
Enhanced security by shifting egress policies from audit to block mode in our GitHub Actions workflow, specifically for steps that involve external network communication. This change restricts outbound traffic, only allowing connections to essential, predefined endpoints (test.pypi.org, upload.pypi.org, api.github.com, and uploads.github.com) during the package testing, uploading, and reporting phases. This proactive measure significantly reduces the risk of unauthorized data transmission, ensuring our CI/CD pipeline adheres to best practices in secure software development.