### PR TITLE
Prepare v1.0.11

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what actually happened.
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - cf-ips-to-hcloud-fw version: [e.g. 1.0.10]
+ - cf-ips-to-hcloud-fw version: [e.g. 1.0.11]
  - Deployment method: [e.g. Docker, Python module]
  - If Python module, Python Version: [e.g. 3.12]
  - If Python module, OS: [e.g. MacOS 14.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [v1.0.11] - 2024-05-09
+
+### Added
+
+- SBOM uploads to GitHub releases (#300)
+- Egress policies for PyPi releases (#299)
+- SBOM and attestations for DockerHub, Quay, GitHub Container Registry (#297)
+- SBOM generation after build (#295)
+- Attestations for python artifacts and sbom (#294)
+- GitHub artifact attestation across registries (#284)
+
+### Changed
+
+- Workflow action versions and naming (#301)
+- SBOM output files naming (#298)
+- Docker workflow security settings (#296)
+- Various dependencies and actions bumped (Refer to commit history for detailed list)
+
 ## [v1.0.10] - 2024-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.0.10
+  jkreileder/cf-ips-to-hcloud-fw:1.0.11
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -122,7 +122,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.0`: This tag always points to the latest `1.0.x` release.
-- `1.0.10`: This tag points to the specific `1.0.10` release.
+- `1.0.11`: This tag points to the specific `1.0.11` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -171,7 +171,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.0.10
+              image: jkreileder/cf-ips-to-hcloud-fw:1.0.11
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false

--- a/src/cf_ips_to_hcloud_fw/version.py
+++ b/src/cf_ips_to_hcloud_fw/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__VERSION__ = "1.0.11-dev"
+__VERSION__ = "1.0.11"


### PR DESCRIPTION
This pull request updates the software to version 1.0.11. It includes several new features and changes, such as SBOM uploads to GitHub releases, egress policies for PyPi releases, and SBOM generation after build. Additionally, various dependencies and actions have been bumped.