### PR TITLE
Tighten egress policy in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -32,7 +32,17 @@ jobs:
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.osv.dev:443
+            api.scorecard.dev:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            www.bestpractices.dev:443
 
       - name: Checkout repository
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5


### PR DESCRIPTION
This pull request enhances the security posture of the GitHub Actions workflow by changing the egress policy from `audit` to `block`. This ensures that the workflow runner can only communicate with trusted services, reducing the risk of data exfiltration and unauthorized access. The egress policy is now specifically configured to allow outbound connections to a curated list of endpoints, including critical services such as GitHub's API, scorecard services, and signature validation endpoints. This aligns with best practices for secure CI/CD pipelines.