### PR TITLE
Update GitHub actions runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Harden runner

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   docker:
     name: Docker build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   publish-test-results:
     name: Publish test results
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
 
     permissions:

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   upload-event-file:
     name: Upload event file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
@@ -32,7 +32,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
@@ -163,7 +163,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - provenance-and-draft-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: test-pypi
       url: https://test.pypi.org/p/cf-ips-to-hcloud-fw
@@ -196,7 +196,7 @@ jobs:
     needs:
       - provenance-and-draft-release
       - publish-to-test-pypi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: pypi
       url: https://pypi.org/p/cf-ips-to-hcloud-fw
@@ -226,7 +226,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - publish-to-pypi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -18,7 +18,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
This pull request updates the GitHub actions runners from `ubuntu-latest` to `ubuntu-24.04`. This change ensures that the actions are executed on the latest version of Ubuntu, providing better compatibility and performance.