### PR TITLE
Update Scorecard workflow to use `ubuntu-latest`

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -18,7 +18,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
This pull request updates the Scorecard workflow to use `ubuntu-latest` instead of `ubuntu-24.04`. The previous version was causing failures due to the issue mentioned in https://github.com/ossf/scorecard-action/issues/1150.

Signed-off-by: Jürgen Kreileder <jk@blackdown.de>