### PR TITLE
Remove deprecated `setup-python-dependencies`

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -65,7 +65,6 @@ jobs:
         uses: github/codeql-action/init@9fdb3e49720b44c48891d036bb502feb25684276 # v3.25.6
         with:
           languages: ${{ matrix.language }}
-          setup-python-dependencies: false
           queries: security-and-quality
 
       - name: Build


### PR DESCRIPTION
This pull request removes the deprecated `setup-python-dependencies` from the codebase.