### PR TITLE
Update ruff-pre-commit to v0.4.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: fc609d3ce5e38f1d32423050196bf0ce4ecc59c1  # frozen: v0.4.5
+    rev: 06206113ba0dbcd25603cb18e0fc191206bbea02  # frozen: v0.4.6
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
This pull request updates the ruff-pre-commit package from version 0.4.5 to version 0.4.6. The update includes a bug fix and improvements to the ruff hook.