### PR TITLE
Update allowed endpoints in codeql.yaml

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -41,6 +41,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            cdn.fwupd.org:443
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443


### PR DESCRIPTION
This pull request updates the allowed endpoints in the `.github/workflows/codeql.yaml` file. The change adds `cdn.fwupd.org:443` to the list of allowed endpoints. This is necessary to ensure that the code can access the necessary resources from `cdn.fwupd.org`.