### PR TITLE
Bump requests from 2.32.2 to 2.32.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -267,9 +267,9 @@ pyyaml==6.0.1 \
     # via
     #   -r requirements.in
     #   cloudflare
-requests==2.32.2 \
-    --hash=sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289 \
-    --hash=sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c
+requests==2.32.3 \
+    --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
+    --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via
     #   cloudflare
     #   hcloud


### PR DESCRIPTION
This pull request updates the requests library from version 2.32.2 to 2.32.3. The update includes changes to the hash values for the library.