### PR TITLE
Update GitHub Actions to use ubuntu-latest

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
@@ -41,7 +41,6 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
-            cdn.fwupd.org:443
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Harden runner

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   docker:
     name: Docker build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   publish-test-results:
     name: Publish test results
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
 
     permissions:

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   upload-event-file:
     name: Upload event file
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
@@ -32,7 +32,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -163,7 +163,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - provenance-and-draft-release
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     environment:
       name: test-pypi
       url: https://test.pypi.org/p/cf-ips-to-hcloud-fw
@@ -196,7 +196,7 @@ jobs:
     needs:
       - provenance-and-draft-release
       - publish-to-test-pypi
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/cf-ips-to-hcloud-fw
@@ -226,7 +226,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - publish-to-pypi
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
 


### PR DESCRIPTION
This pull request updates the GitHub Actions configuration to use the `ubuntu-latest` operating system instead of `ubuntu-24.04`. This change is made because `ubuntu-24.04` is not stable enough.