### PR TITLE
Update ruff pre-commit hook to version 0.4.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: f42857794802b6a77b0e66f08803575aa80d3c8f  # frozen: v0.4.7
+    rev: 99e5311c54112fde9d58021fe477b3ba7aab20d4  # frozen: v0.4.8
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
This pull request updates the ruff pre-commit hook to version 0.4.8. The previous version was 0.4.7. This update includes bug fixes and improvements.