### PR TITLE
Update Dockerfile syntax to version 1.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.7.1@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
+# syntax = docker/dockerfile:1.8.1@sha256:e87caa74dcb7d46cd820352bfea12591f3dba3ddc4285e19c7dcd13359f7cefd
 
 FROM --platform=$BUILDPLATFORM python:3.12.4-slim-bookworm@sha256:2fba8e70a87bcc9f6edd20dda0a1d4adb32046d2acbca7361bc61da5a106a914 AS builder
 


### PR DESCRIPTION
This pull request updates the Dockerfile syntax to version 1.8.1. The previous version was 1.7.1. This update ensures compatibility with the latest Dockerfile syntax and improves the overall stability and security of the project.