### PR TITLE
Update cloudflare library to version 3.0.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -71,7 +71,9 @@ coverage[toml]==7.6.0 \
 exceptiongroup==1.2.2 \
     --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b \
     --hash=sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 importlib-metadata==8.0.0 \
     --hash=sha256:15584cf2b1bf449d98ff8a6ff1abef57bf20f3ac6454f431736cd3e660921b2f \
     --hash=sha256:188bd24e4c346d3f0a933f275c2fec67050326a856b9a359881d7c2a697e8812

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-cloudflare < 3
+cloudflare
 hcloud
 pydantic
 PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,14 +8,19 @@ annotated-types==0.7.0 \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
     # via pydantic
-attrs==23.2.0 \
-    --hash=sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30 \
-    --hash=sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1
-    # via jsonlines
+anyio==4.4.0 \
+    --hash=sha256:5aadc6a1bbb7cdb0bede386cac5e2940f5e2ff3aa20277e991cf028e0585ce94 \
+    --hash=sha256:c1b2d8f46a8a812513012e1107cb0e68c17159a7a594208005a57dc776e1bdc7
+    # via
+    #   cloudflare
+    #   httpx
 certifi==2024.7.4 \
     --hash=sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b \
     --hash=sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 charset-normalizer==3.3.2 \
     --hash=sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027 \
     --hash=sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087 \
@@ -108,25 +113,47 @@ charset-normalizer==3.3.2 \
     --hash=sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519 \
     --hash=sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561
     # via requests
-cloudflare==2.20.0 \
-    --hash=sha256:46aefc39dfaa2365d639b423cec2cd5350ae11153c7247d3eb3545bdcf01a68a
+cloudflare==3.0.1 \
+    --hash=sha256:212ead08c8bd9ea1796286bb5d954d157991b3dbcab0c526332f775298ccce9f \
+    --hash=sha256:e0d475486fccccd71eb9892cd91358b25bbdab103f8154d7847f1136d4f69fd2
     # via -r requirements.in
+distro==1.9.0 \
+    --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
+    --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
+    # via cloudflare
+exceptiongroup==1.2.2 \
+    --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b \
+    --hash=sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc
+    # via anyio
+h11==0.14.0 \
+    --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
+    --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
+    # via httpcore
 hcloud==2.0.1 \
     --hash=sha256:35fe2b9159173c43cf67ec410a77ca7d87a08017e1b208a39c0209cc1c91e3a0 \
     --hash=sha256:3b068dacac99fb967a7de25e64d23daad3f2fb586f3145ba831b3fd70848522c
     # via -r requirements.in
+httpcore==1.0.5 \
+    --hash=sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61 \
+    --hash=sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5
+    # via httpx
+httpx==0.27.0 \
+    --hash=sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5 \
+    --hash=sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5
+    # via cloudflare
 idna==3.7 \
     --hash=sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc \
     --hash=sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
-    # via requests
-jsonlines==4.0.0 \
-    --hash=sha256:0c6d2c09117550c089995247f605ae4cf77dd1533041d366351f6f298822ea74 \
-    --hash=sha256:185b334ff2ca5a91362993f42e83588a360cf95ce4b71a73548502bda52a7c55
-    # via cloudflare
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 pydantic==2.8.2 \
     --hash=sha256:6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a \
     --hash=sha256:73ee9fddd406dc318b885c7a2eab8a6472b68b8fb5ba8150949fc3db939f23c8
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   cloudflare
 pydantic-core==2.20.1 \
     --hash=sha256:035ede2e16da7281041f0e626459bcae33ed998cca6a0a007a5ebb73414ac72d \
     --hash=sha256:04024d270cf63f586ad41fff13fde4311c4fc13ea74676962c876d9577bcc78f \
@@ -274,23 +301,28 @@ pyyaml==6.0.1 \
     --hash=sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585 \
     --hash=sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d \
     --hash=sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f
-    # via
-    #   -r requirements.in
-    #   cloudflare
+    # via -r requirements.in
 requests==2.32.3 \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
-    # via
-    #   cloudflare
-    #   hcloud
+    # via hcloud
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via python-dateutil
+sniffio==1.3.1 \
+    --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
+    --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
+    # via
+    #   anyio
+    #   cloudflare
+    #   httpx
 typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
     # via
+    #   anyio
+    #   cloudflare
     #   pydantic
     #   pydantic-core
 urllib3==2.2.2 \

--- a/tests/test_cloudflare.py
+++ b/tests/test_cloudflare.py
@@ -2,33 +2,78 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import CloudFlare  # type: ignore[import-untyped]
+import cloudflare
+import cloudflare.types.ips
+import httpx
 import pytest
 
 from cf_ips_to_hcloud_fw.cloudflare import (
-    cf_ips_get,  # type: ignore[import-untyped]
+    cf_ips_list,
     get_cloudflare_cidrs,
 )
 from cf_ips_to_hcloud_fw.models import CloudflareCIDRs
 
 
-@patch("CloudFlare.CloudFlare")
+@patch("cloudflare.Cloudflare")
 @patch("logging.error")
-def test_cf_ips_get(mock_logging: MagicMock, mock_cloudflare: MagicMock) -> None:
-    mock_cloudflare.return_value.ips.get.side_effect = (
-        CloudFlare.exceptions.CloudFlareAPIError(503, "503")  # type: ignore[assignment]
+def test_cf_ips_list_api_connection_error(
+    mock_logging: MagicMock, mock_cloudflare: MagicMock
+) -> None:
+    mock_cloudflare.return_value.ips.list.side_effect = cloudflare.APITimeoutError(
+        httpx.Request("GET", "https://api.cloudflare.com/client/v4/ips")
     )
     with pytest.raises(SystemExit) as e:
-        cf_ips_get()
+        cf_ips_list()
     assert e.type is SystemExit
     assert e.value.code == 1
-    mock_cloudflare.return_value.ips.get.assert_called_once()
-    mock_logging.assert_called_once_with("Error getting CloudFlare IPs: 503")
+    mock_cloudflare.return_value.ips.list.assert_called_once()
+    mock_logging.assert_called_once_with(
+        "Error getting CloudFlare IPs: Request timed out."
+    )
+
+
+@patch("cloudflare.Cloudflare")
+@patch("logging.error")
+def test_cf_ips_list_api_status_error(
+    mock_logging: MagicMock, mock_cloudflare: MagicMock
+) -> None:
+    mock_cloudflare.return_value.ips.list.side_effect = cloudflare.RateLimitError(
+        "rate-limit",
+        response=httpx.Response(
+            status_code=200,
+            request=httpx.Request("GET", "https://api.cloudflare.com/client/v4/ips"),
+        ),
+        body=None,
+    )
+    with pytest.raises(SystemExit) as e:
+        cf_ips_list()
+    assert e.type is SystemExit
+    assert e.value.code == 1
+    mock_cloudflare.return_value.ips.list.assert_called_once()
+    mock_logging.assert_called_once_with("Error getting CloudFlare IPs: rate-limit")
 
 
 @patch(
-    "cf_ips_to_hcloud_fw.cloudflare.cf_ips_get",
-    MagicMock(return_value={"ipv4_cidrs": ["199.27.128.0/21", "198.27.128.0/21"]}),
+    "cf_ips_to_hcloud_fw.cloudflare.cf_ips_list",
+    MagicMock(return_value=None),
+)
+@patch("logging.error")
+def test_get_cloudflare_cidrs_no_response(mock_logging: MagicMock) -> None:
+    with pytest.raises(SystemExit) as e:
+        get_cloudflare_cidrs()
+    assert e.type is SystemExit
+    assert e.value.code == 1
+    mock_logging.assert_called_once_with("Cloudflare/ips.list: no response")
+
+
+@patch(
+    "cf_ips_to_hcloud_fw.cloudflare.cf_ips_list",
+    MagicMock(
+        return_value=cloudflare.types.ips.IPs(
+            ipv4_cidrs=["399.27.128.0/21", "198.27.128.0/21"],
+            ipv6_cidrs=["2400:cb00::/32", "1400:cb00::/32"],
+        )
+    ),
 )
 @patch("logging.error")
 def test_get_cloudflare_cidrs_invalid(mock_logging: MagicMock) -> None:
@@ -37,16 +82,16 @@ def test_get_cloudflare_cidrs_invalid(mock_logging: MagicMock) -> None:
     assert e.type is SystemExit
     assert e.value.code == 1
     mock_logging.assert_called_once()
-    assert "Cloudflare/ips.get didn't validate" in mock_logging.call_args[0][0]
+    assert "Cloudflare/ips.list didn't validate" in mock_logging.call_args[0][0]
 
 
 @patch(
-    "cf_ips_to_hcloud_fw.cloudflare.cf_ips_get",
+    "cf_ips_to_hcloud_fw.cloudflare.cf_ips_list",
     MagicMock(
-        return_value={
-            "ipv4_cidrs": ["199.27.128.0/21", "198.27.128.0/21"],
-            "ipv6_cidrs": ["2400:cb00::/32", "1400:cb00::/32"],
-        }
+        return_value=cloudflare.types.ips.IPs(
+            ipv4_cidrs=["199.27.128.0/21", "198.27.128.0/21"],
+            ipv6_cidrs=["2400:cb00::/32", "1400:cb00::/32"],
+        )
     ),
 )
 def test_get_cloudflare_cidrs() -> None:


### PR DESCRIPTION
This pull request updates the cloudflare library from version 2.20.0 to version 3.0.1. It also includes code and test adaptations to accommodate the library update.