### PR TITLE
Update pytest to version 8.3.2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -110,9 +110,9 @@ pyright==1.1.373 \
     --hash=sha256:b805413227f2c209f27b14b55da27fe5e9fb84129c9f1eb27708a5d12f6f000e \
     --hash=sha256:f41bcfc8b9d1802b09921a394d6ae1ce19694957b628bc657629688daf8a83ff
     # via -r requirements-dev.in
-pytest==8.3.1 \
-    --hash=sha256:7e8e5c5abd6e93cb1cc151f23e57adc31fcf8cfd2a3ff2da63e23f732de35db6 \
-    --hash=sha256:e9600ccf4f563976e2c99fa02c7624ab938296551f280835ee6516df8bc4ae8c
+pytest==8.3.2 \
+    --hash=sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5 \
+    --hash=sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce
     # via
     #   -r requirements-dev.in
     #   pytest-cov


### PR DESCRIPTION
This pull request updates the pytest library from version 8.3.1 to version 8.3.2. The update includes bug fixes and improvements.