### PR TITLE
Add grype.anchore.io to allowed list in Docker workflow configuration

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,6 +44,7 @@ jobs:
             fulcio.sigstore.dev:443
             ghcr.io:443
             github.com:443
+            grype.anchore.io:443
             hub.docker.com:443
             index.docker.io:443
             nodejs.org:443


### PR DESCRIPTION
Signed-off-by: Jürgen Kreileder <jk@blackdown.de>