### PR TITLE
Update ruff pre-commit hook to version 0.6.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 8b5112a3b2ad121439a2092f8ff548c0d80f2514  # frozen: v0.6.1
+    rev: 24d039e647a08707e6cb31e75e01844eeff925e7  # frozen: v0.6.2
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
This pull request updates the ruff pre-commit hook from version 0.6.1 to version 0.6.2. The update includes changes to the `repos` section of the configuration file, specifically the `rev` value for the ruff-pre-commit repository. The new version of the hook includes bug fixes and improvements.