### PR TITLE
Update SBOM generator version to 1.14.1 in Docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -124,7 +124,7 @@ jobs:
           pull: true
           push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
           load: ${{ github.event_name == 'pull_request' || github.actor == 'dependabot[bot]' }}
-          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.13.0@sha256:b19ad00af1515f55556a032e3980c3a423f14359a915dfa16609934c6e32c3f0' || '' }}
+          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.14.1@sha256:3e225c7cd33fb08121f4a633fa2b4cc51e7ec2be9a9273f7d7836e7a4a9816de' || '' }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}


### PR DESCRIPTION
This pull request updates the SBOM generator version in the Docker workflow from 1.13.0 to 1.14.1, ensuring that the latest features and fixes are incorporated into the build process.