### PR TITLE
Bump Dockerfile syntax version to 1.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.9.0@sha256:fe40cf4e92cd0c467be2cfc30657a680ae2398318afd50b0c80585784c604f28
+# syntax = docker/dockerfile:1.10.0@sha256:865e5dd094beca432e8c0a1d5e1c465db5f998dca4e439981029b3b81fb39ed5
 
 FROM --platform=$BUILDPLATFORM python:3.12.5-slim-bookworm@sha256:59c7332a4a24373861c4a5f0eec2c92b87e3efeb8ddef011744ef9a751b1d11c AS builder
 


### PR DESCRIPTION
This PR updates the Dockerfile syntax version from 1.9.0 to 1.10.0, ensuring compatibility with the latest features and improvements in the Dockerfile syntax.