### PR TITLE
Leverage GitHub Actions caching and remove the unnecessary `pull` option

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -121,7 +121,6 @@ jobs:
         with:
           context: .
           platforms: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'linux/amd64,linux/arm64' || '' }}
-          pull: true
           push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
           load: ${{ github.event_name == 'pull_request' || github.actor == 'dependabot[bot]' }}
           sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.14.1@sha256:3e225c7cd33fb08121f4a633fa2b4cc51e7ec2be9a9273f7d7836e7a4a9816de' || '' }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -127,6 +127,8 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Generate SBOM
         if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/docker.yaml` file to enhance the Docker build process. The most important changes involve the addition of caching options to improve build efficiency.

Improvements to Docker build process:

* [`.github/workflows/docker.yaml`](diffhunk://#diff-17e3400d876978d12bbad517dcf82312b54fa62723408b1ce011b2755458bdafL124-R131): Added `cache-from` and `cache-to` options to leverage GitHub Actions caching and removed the `pull` option to streamline the build process.