### PR TITLE
Make build check errors fatal and enable experimental checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # syntax = docker/dockerfile:1.10.0@sha256:865e5dd094beca432e8c0a1d5e1c465db5f998dca4e439981029b3b81fb39ed5
+# check=experimental=all;error=true
 
 FROM --platform=$BUILDPLATFORM python:3.13.0-slim-bookworm@sha256:2ec5a4a5c3e919570f57675471f081d6299668d909feabd8d4803c6c61af666c AS builder
 


### PR DESCRIPTION
This PR modifies the build configuration to make errors from checks fatal and enables experimental checks. This change aims to improve build reliability and ensure that all checks are strictly enforced during the build process.