### PR TITLE
Bump ruff-pre-commit from 0.6.9 to 0.7.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 75b98813cfb7e663870a28c74366a1e99d7bfe79  # frozen: v0.6.9
+    rev: 8983acb92ee4b01924893632cf90af926fa608f0  # frozen: v0.7.0
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
This pull request updates the ruff-pre-commit dependency from version 0.6.9 to 0.7.0, ensuring that the latest features and fixes are incorporated into the project.