### PR TITLE
Bump ruff-pre-commit from v0.7.0 to v0.7.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 8983acb92ee4b01924893632cf90af926fa608f0  # frozen: v0.7.0
+    rev: 4edcbde74af0cd9b38e8483828cd9c6cb0755276  # frozen: v0.7.1
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
This pull request updates the `ruff-pre-commit` dependency from version 0.7.0 to 0.7.1, ensuring that the latest features and fixes are incorporated. The change is reflected in the configuration file, updating the frozen revision accordingly.