### PR TITLE
Bump pip to version 24.3.1 and update hashes

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -174,9 +174,9 @@ zipp==3.20.2 \
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.2 \
-    --hash=sha256:2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2 \
-    --hash=sha256:5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8
+pip==24.3.1 \
+    --hash=sha256:3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed \
+    --hash=sha256:ebcb60557f2aefabc2e0f918751cd24ea0d56d8ec5445fe1807f1d2109660b99
     # via pip-tools
 setuptools==75.2.0 \
     --hash=sha256:753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec \


### PR DESCRIPTION
This pull request updates the pip package from version 24.2 to 24.3.1 in the `requirements-dev.txt` file, along with the corresponding hash values for verification. This ensures that the development environment uses the latest version of pip with the correct integrity checks.