### PR TITLE
Bump scout-sbom-indexer to version 1.15.0 in Docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -123,7 +123,7 @@ jobs:
           platforms: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'linux/amd64,linux/arm64' || '' }}
           push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
           load: ${{ github.event_name == 'pull_request' || github.actor == 'dependabot[bot]' }}
-          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.14.1@sha256:3e225c7cd33fb08121f4a633fa2b4cc51e7ec2be9a9273f7d7836e7a4a9816de' || '' }}
+          sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.15.0@sha256:4fa68d539eb5a99e75a93dfbefe5a4dfacd9c90c4577925f492670c6a1b06894' || '' }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}


### PR DESCRIPTION
This pull request updates the Docker workflow to use scout-sbom-indexer version 1.15.0, ensuring that the latest features and fixes are incorporated into the build process.