### PR TITLE
Prepare for v1.0.13 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,10 +24,10 @@ A clear and concise description of what actually happened.
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - cf-ips-to-hcloud-fw version: [e.g. 1.0.12]
+ - cf-ips-to-hcloud-fw version: [e.g. 1.0.13]
  - Deployment method: [e.g. Docker, Python module]
  - If Python module, Python Version: [e.g. 3.13]
- - If Python module, OS: [e.g. MacOS 14.3]
+ - If Python module, OS: [e.g. MacOS 15.1]
 
 **Additional context**
 Add any other context about the problem here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v1.0.13] - 2024-11-07
+
+Maintenance release with updated dependencies.
+
 ## [v1.0.12] - 2024-07-15
 
 Maintenance release with updated dependencies.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.0.12
+  jkreileder/cf-ips-to-hcloud-fw:1.0.13
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -123,7 +123,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.0`: This tag always points to the latest `1.0.x` release.
-- `1.0.12`: This tag points to the specific `1.0.12` release.
+- `1.0.13`: This tag points to the specific `1.0.13` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -172,7 +172,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.0.12
+              image: jkreileder/cf-ips-to-hcloud-fw:1.0.13
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false

--- a/src/cf_ips_to_hcloud_fw/version.py
+++ b/src/cf_ips_to_hcloud_fw/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__VERSION__ = "1.0.13-dev"
+__VERSION__ = "1.0.13"


### PR DESCRIPTION
Update versioning and documentation for the v1.0.13 release, including changes to dependencies and Docker image tags.