### PR TITLE
Prepare v1.0.14

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what actually happened.
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - cf-ips-to-hcloud-fw version: [e.g. 1.0.13]
+ - cf-ips-to-hcloud-fw version: [e.g. 1.0.14]
  - Deployment method: [e.g. Docker, Python module]
  - If Python module, Python Version: [e.g. 3.13]
  - If Python module, OS: [e.g. MacOS 15.1]

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -176,7 +176,7 @@ jobs:
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             ghcr.io:443
             test.pypi.org:443
@@ -210,7 +210,7 @@ jobs:
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           disable-sudo: true
-          egress-policy: block
+          egress-policy: audit
           allowed-endpoints: >
             ghcr.io:443
             upload.pypi.org:443

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -178,6 +178,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            ghcr.io:443
             test.pypi.org:443
 
       - name: Download all the distribution packages
@@ -211,6 +212,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            ghcr.io:443
             upload.pypi.org:443
 
       - name: Download all the distribution packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v1.0.14] - 2024-11-07
+
+Maintenance release with fix PyPi release workflow.
+
 ## [v1.0.13] - 2024-11-07
 
 Maintenance release with updated dependencies.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.0.13
+  jkreileder/cf-ips-to-hcloud-fw:1.0.14
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -123,7 +123,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.0`: This tag always points to the latest `1.0.x` release.
-- `1.0.13`: This tag points to the specific `1.0.13` release.
+- `1.0.14`: This tag points to the specific `1.0.14` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -172,7 +172,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.0.13
+              image: jkreileder/cf-ips-to-hcloud-fw:1.0.14
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false

--- a/src/cf_ips_to_hcloud_fw/version.py
+++ b/src/cf_ips_to_hcloud_fw/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__VERSION__ = "1.0.13"
+__VERSION__ = "1.0.14"


### PR DESCRIPTION
Release version 1.0.14, allowing access to ghcr.io in the PyPi publish workflow and changing the egress policy from block to audit in GitHub Actions.