### PR TITLE
Update egress policy and allowed endpoints for pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -176,10 +176,14 @@ jobs:
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
+            fulcio.sigstore.dev:443
             ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            rekor.sigstore.dev:443
             test.pypi.org:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Download all the distribution packages
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -210,9 +214,13 @@ jobs:
         uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
           allowed-endpoints: >
+            fulcio.sigstore.dev:443
             ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
             upload.pypi.org:443
 
       - name: Download all the distribution packages


### PR DESCRIPTION
Change the egress policy from audit to block and add several allowed endpoints to enhance security for the pypa/gh-action-pypi-publish action.