### PR TITLE
Add additional ports for files.pythonhosted.org and pypi.org in Docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,6 +41,7 @@ jobs:
             auth.docker.io:443
             cdn03.quay.io:443
             files.pythonhosted.org:443
+            files.pythonhosted.org:65535
             fulcio.sigstore.dev:443
             ghcr.io:443
             github.com:443
@@ -52,6 +53,7 @@ jobs:
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
             pypi.org:443
+            pypi.org:65535
             quay.io:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443


### PR DESCRIPTION
Include extra ports in the Docker workflow configuration to enhance connectivity for files.pythonhosted.org and pypi.org.