### PR TITLE
Add cloudflarestorage.com to allowed hosts

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,6 +40,7 @@ jobs:
             api.scout.docker.com:443
             auth.docker.io:443
             cdn03.quay.io:443
+            cloudflarestorage.com:443
             files.pythonhosted.org:443
             files.pythonhosted.org:65535
             fulcio.sigstore.dev:443


### PR DESCRIPTION
Include cloudflarestorage.com in the list of allowed hosts for network requests.