### PR TITLE
Bump certifi to version 2024.12.14 and update hashes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,9 @@ anyio==4.7.0 \
     # via
     #   cloudflare
     #   httpx
-certifi==2024.8.30 \
-    --hash=sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8 \
-    --hash=sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9
+certifi==2024.12.14 \
+    --hash=sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56 \
+    --hash=sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db
     # via
     #   httpcore
     #   httpx


### PR DESCRIPTION
Update the certifi package to the latest version and refresh the associated hashes.