### PR TITLE
Switch back to using CODECOV_TOKEN for coverage reporting

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -107,7 +107,7 @@ jobs:
         with:
           files: ./coverage.xml
           flags: python-${{ matrix.python-version }}
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build
         run: make build


### PR DESCRIPTION
Revert to using CODECOV_TOKEN instead of OIDC for coverage reporting to prevent frequent breakages.