### PR TITLE
Bump SLSA GitHub generator workflows to version 2.1.0

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -247,7 +247,7 @@ jobs:
       id-token: write
       packages: write
     # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ vars.DOCKERHUB_USERNAME }}/cf-ips-to-hcloud-fw
       digest: ${{ needs.docker.outputs.digest }}
@@ -266,7 +266,7 @@ jobs:
       id-token: write
       packages: write
     # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: quay.io/${{ vars.QUAY_USERNAME }}/cf-ips-to-hcloud-fw
       digest: ${{ needs.docker.outputs.digest }}
@@ -285,7 +285,7 @@ jobs:
       id-token: write
       packages: write
     # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ghcr.io/${{ github.repository_owner }}/cf-ips-to-hcloud-fw
       digest: ${{ needs.docker.outputs.digest }}

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -164,7 +164,7 @@ jobs:
       id-token: write
       contents: write
     # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.build.outputs.hashes }}
       upload-assets: true


### PR DESCRIPTION
Update the SLSA GitHub generator workflows to the latest version for improved functionality and performance.