### PR TITLE
Add dependency groups for Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,11 +4,23 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      pip-deps:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      action-deps:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      docker-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
Introduce dependency groups for pip, GitHub Actions, and Docker in the Dependabot configuration to enhance dependency management.