### PR TITLE
Update license format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "Jürgen Kreileder" }, { email = "jk@blackdown.de" }]
 description = "Update Hetzner Cloud firewall rules with Cloudflare IP ranges"
 keywords = ["cloudflare", "hcloud", "hetzner", "firewall", "cli"]
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.9"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 classifiers = [
@@ -17,7 +17,6 @@ classifiers = [
     "Environment :: Other Environment",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Change the license format in `pyproject.toml` to comply with PEP 639 standards.