### PR TITLE
Prepare for v1.0.16 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what actually happened.
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - cf-ips-to-hcloud-fw version: [e.g. 1.0.15]
+ - cf-ips-to-hcloud-fw version: [e.g. 1.0.16]
  - Deployment method: [e.g. Docker, Python module]
  - If Python module, Python Version: [e.g. 3.13]
  - If Python module, OS: [e.g. MacOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.0.16] – 2025-06-19
+
+Maintenance release with dependency and CI updates.
+
+- Updated Python and Docker base images
+- Bumped ruff, codeql-action, and other dependencies
+- Minor improvements to CI workflows
+
 ## [v1.0.15] – 2024-12-22
 
 Maintenance release with updated dependencies.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.0.15
+  jkreileder/cf-ips-to-hcloud-fw:1.0.16
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -123,7 +123,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.0`: This tag always points to the latest `1.0.x` release.
-- `1.0.15`: This tag points to the specific `1.0.15` release.
+- `1.0.16`: This tag points to the specific `1.0.16` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -172,7 +172,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.0.15
+              image: jkreileder/cf-ips-to-hcloud-fw:1.0.16
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false

--- a/src/cf_ips_to_hcloud_fw/version.py
+++ b/src/cf_ips_to_hcloud_fw/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__VERSION__ = "1.0.16-dev"
+__VERSION__ = "1.0.16"


### PR DESCRIPTION
Update version to 1.0.16, enhance dependencies, and improve CI workflows in this maintenance release.