### PR TITLE
Bump version to 1.0.17 and enhance firewall rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ A clear and concise description of what actually happened.
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - cf-ips-to-hcloud-fw version: [e.g. 1.0.16]
+ - cf-ips-to-hcloud-fw version: [e.g. 1.0.17]
  - Deployment method: [e.g. Docker, Python module]
  - If Python module, Python Version: [e.g. 3.13]
  - If Python module, OS: [e.g. MacOS 15.1]

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,6 +39,8 @@ jobs:
             api.github.com:443
             api.scout.docker.com:443
             auth.docker.io:443
+            cdn01.quay.io:443
+            cdn02.quay.io:443
             cdn03.quay.io:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
             files.pythonhosted.org:443

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [v1.0.16] – 2025-06-19
+## [v1.0.17] – 2025-06-20
+
+Fix StepSecurity policy
+
+## [v1.0.16] – 2025-06-20
 
 Maintenance release with dependency and CI updates.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.0.16
+  jkreileder/cf-ips-to-hcloud-fw:1.0.17
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -123,7 +123,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.0`: This tag always points to the latest `1.0.x` release.
-- `1.0.16`: This tag points to the specific `1.0.16` release.
+- `1.0.17`: This tag points to the specific `1.0.17` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -172,7 +172,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.0.16
+              image: jkreileder/cf-ips-to-hcloud-fw:1.0.17
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false

--- a/src/cf_ips_to_hcloud_fw/version.py
+++ b/src/cf_ips_to_hcloud_fw/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__VERSION__ = "1.0.16"
+__VERSION__ = "1.0.17"


### PR DESCRIPTION
Update the version to 1.0.17, improve firewall rules, and fix the StepSecurity policy. Adjust documentation and examples to reflect the new version.