### PR TITLE
Add release-assets.githubusercontent.com and get.anchore.io to allowed hosts in workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -46,6 +46,7 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            release-assets.githubusercontent.com:443
             uploads.github.com:443
 
       - name: Checkout repository

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -61,6 +61,7 @@ jobs:
             registry.npmjs.org:443
             registry.scout.docker.com:443
             rekor.sigstore.dev:443
+            release-assets.githubusercontent.com:443
             toolbox-data.anchore.io:443
             tuf-repo-cdn.sigstore.dev:443
             uploads.github.com:443

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,6 +45,7 @@ jobs:
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
             files.pythonhosted.org:443
             fulcio.sigstore.dev:443
+            get.anchore.io:443
             ghcr.io:443
             github.com:443
             grype.anchore.io:443

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -62,6 +62,7 @@ jobs:
             codecov.io:443
             files.pythonhosted.org:443
             fulcio.sigstore.dev:443
+            get.anchore.io:443
             github.com:443
             ingest.codecov.io:443
             keybase.io:443
@@ -71,6 +72,7 @@ jobs:
             raw.githubusercontent.com:443
             registry.npmjs.org:443
             rekor.sigstore.dev:443
+            release-assets.githubusercontent.com:443
             storage.googleapis.com:443
             uploader.codecov.io:443
             uploads.github.com:443


### PR DESCRIPTION
Include `release-assets.githubusercontent.com` in the list of allowed hosts for workflows to enable access to release assets.