### PR TITLE
chore: Add production.cloudfront.docker.com to allowed hosts

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -56,6 +56,7 @@ jobs:
             objects.githubusercontent.com:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             public.ecr.aws:443
             pypi.org:443
             quay.io:443


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Adds `production.cloudfront.docker.com` to the list of allowed hosts for outbound connections within the GitHub Actions workflow. This enables the workflow to connect to this domain, likely for Docker image operations, on port 443.
<!-- kody-pr-summary:end -->