### PR TITLE
chore: use SLSA provenance v1 in docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -130,6 +130,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
           load: ${{ github.event_name == 'pull_request' || github.actor == 'dependabot[bot]' }}
           sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.18.2@sha256:3579229a5ace351e4511903f3da976304990339da1c49a3cc0f00bcd7d793181' || '' }}
+          provenance: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'mode=max,version=v1' || '' }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [v1.2.2] – Unreleased
 
+- Upgraded Docker build provenance attestations to use the stable SLSA v1 schema
 - Start new development cycle
 
 ## [v1.2.1] – 2026-05-30


### PR DESCRIPTION
Upgrade the Docker build provenance attestation schema version from v0.2 to v1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration to improve supply chain security through provenance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->