### PR TITLE
feat(config)!: enforce POSIX config permission checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.2.2] – Unreleased
+## [v1.3.0] – Unreleased
 
 - Upgraded Docker build provenance attestations to use the stable SLSA v1 schema
+- **Breaking:** Added POSIX config-permission checks that reject group/other
+  writable config files while allowing common read-only Docker/Kubernetes
+  secret mounts with a warning
 - Start new development cycle
 
 ## [v1.2.1] – 2026-05-30

--- a/README.md
+++ b/README.md
@@ -253,6 +253,16 @@ your API tokens and the names of the firewalls you want to update:
     - default
 ```
 
+On POSIX systems, the tool checks config file permissions before loading the
+file:
+
+- Config files writable by group or others are rejected.
+- Group/other read access is allowed (common for mounted read-only
+  Docker/Kubernetes secrets), but a warning is logged.
+
+For local files, prefer owner-only access (for example `chmod 600 config.yaml`)
+where practical.
+
 ## Usage
 
 Run the tool with your configuration file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.2.2.dev1"
+version = "1.3.0.dev1"
 dependencies = [
     "cloudflare>=5.2.0",
     "hcloud>=2.20.0",

--- a/src/cf_ips_to_hcloud_fw/config.py
+++ b/src/cf_ips_to_hcloud_fw/config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import stat
 import sys
 
 import yaml
@@ -8,6 +10,35 @@ from pydantic import TypeAdapter, ValidationError
 
 from cf_ips_to_hcloud_fw.custom_logging import log_error_and_exit
 from cf_ips_to_hcloud_fw.models import Project
+
+
+def _validate_config_permissions(config_file: str) -> None:
+    """Reject group/world-accessible config files on Unix-like platforms.
+
+    Args:
+        config_file: Absolute or relative path to the YAML config file.
+    """
+    if os.name != "posix" or not os.path.exists(config_file):
+        return
+
+    try:
+        mode = stat.S_IMODE(os.stat(config_file).st_mode)
+    except OSError as e:
+        log_error_and_exit(
+            f"Couldn't check permissions of config file {config_file!r}: {e}"
+        )
+
+    if mode & (stat.S_IWGRP | stat.S_IWOTH):
+        log_error_and_exit(
+            f"Config file {config_file!r} has insecure permissions "
+            f"({mode:o}); group/other write bits are not allowed."
+        )
+
+    if mode & (stat.S_IRGRP | stat.S_IROTH | stat.S_IXGRP | stat.S_IXOTH):
+        logging.warning(
+            f"Config file {config_file!r} permissions are permissive ({mode:o}); "
+            "consider owner-only access (for example 600) when possible."
+        )
 
 
 def read_config(config_file: str) -> list[Project]:
@@ -19,6 +50,8 @@ def read_config(config_file: str) -> list[Project]:
     Returns:
         list[Project]: Ordered list of validated project definitions.
     """
+    _validate_config_permissions(config_file)
+
     try:
         with open(config_file, encoding="utf-8") as file:
             config = yaml.safe_load(file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import stat
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -7,6 +8,112 @@ from pydantic import SecretStr
 
 from cf_ips_to_hcloud_fw.config import read_config
 from cf_ips_to_hcloud_fw.models import Project
+
+
+@patch("cf_ips_to_hcloud_fw.config.os.name", "posix")
+@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
+@patch("cf_ips_to_hcloud_fw.config.os.stat")
+@patch("logging.error")
+def test_read_config_permission_stat_error(
+    mock_logging: MagicMock,
+    mock_stat: MagicMock,
+    mock_exists: MagicMock,
+) -> None:
+    """Exit with an error when config permission metadata cannot be read."""
+    mock_stat.side_effect = OSError("boom")
+
+    with pytest.raises(SystemExit) as e:
+        read_config("config.yaml")
+
+    assert e.value.code == 1
+    mock_exists.assert_called_once_with("config.yaml")
+    mock_stat.assert_called_once_with("config.yaml")
+    mock_logging.assert_called_once()
+    assert (
+        "Couldn't check permissions of config file 'config.yaml': boom"
+        in mock_logging.call_args[0][0]
+    )
+
+
+@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
+@patch("cf_ips_to_hcloud_fw.config.os.stat")
+@patch("logging.warning")
+def test_read_config_permissive_read_permissions_warn(
+    mock_warning: MagicMock,
+    mock_stat: MagicMock,
+    mock_exists: MagicMock,
+) -> None:
+    """Allow read-only group access (common for mounted secrets) but warn."""
+    mock_stat.return_value = MagicMock(st_mode=stat.S_IFREG | 0o640)
+
+    with patch(
+        "builtins.open",
+        mock_open(
+            read_data="""
+- token: token
+  firewalls:
+    - fw-1
+""",
+        ),
+    ):
+        projects = read_config("config.yaml")
+
+    assert projects == [Project(token=SecretStr("token"), firewalls=["fw-1"])]
+    mock_exists.assert_called_once_with("config.yaml")
+    mock_stat.assert_called_once_with("config.yaml")
+    mock_warning.assert_called_once_with(
+        "Config file 'config.yaml' permissions are permissive (640); "
+        "consider owner-only access (for example 600) when possible."
+    )
+
+
+@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
+@patch("cf_ips_to_hcloud_fw.config.os.stat")
+@patch(
+    "builtins.open",
+    mock_open(
+        read_data="""
+- token: token
+  firewalls:
+    - fw-1
+""",
+    ),
+)
+def test_read_config_secure_permissions(
+    mock_stat: MagicMock,
+    mock_exists: MagicMock,
+) -> None:
+    """Allow owner-only config files to be parsed normally."""
+    mock_stat.return_value = MagicMock(st_mode=stat.S_IFREG | 0o600)
+
+    projects = read_config("config.yaml")
+
+    assert projects == [Project(token=SecretStr("token"), firewalls=["fw-1"])]
+    mock_exists.assert_called_once_with("config.yaml")
+    mock_stat.assert_called_once_with("config.yaml")
+
+
+@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
+@patch("cf_ips_to_hcloud_fw.config.os.stat")
+@patch("logging.error")
+def test_read_config_group_or_world_writable_permissions_rejected(
+    mock_logging: MagicMock,
+    mock_stat: MagicMock,
+    mock_exists: MagicMock,
+) -> None:
+    """Reject config files writable by group/others."""
+    mock_stat.return_value = MagicMock(st_mode=stat.S_IFREG | 0o666)
+
+    with pytest.raises(SystemExit) as e:
+        read_config("config.yaml")
+
+    assert e.value.code == 1
+    mock_exists.assert_called_once_with("config.yaml")
+    mock_stat.assert_called_once_with("config.yaml")
+    mock_logging.assert_called_once_with(
+        "Config file 'config.yaml' has insecure permissions (666); "
+        "group/other write bits are not allowed."
+    )
 
 
 @patch("builtins.open", side_effect=FileNotFoundError("config.yaml"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,7 @@ def test_read_config_permission_stat_error(
     )
 
 
+@patch("cf_ips_to_hcloud_fw.config.os.name", "posix")
 @patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
 @patch("cf_ips_to_hcloud_fw.config.os.stat")
 @patch("logging.warning")
@@ -67,6 +68,7 @@ def test_read_config_permissive_read_permissions_warn(
     )
 
 
+@patch("cf_ips_to_hcloud_fw.config.os.name", "posix")
 @patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
 @patch("cf_ips_to_hcloud_fw.config.os.stat")
 @patch(
@@ -93,6 +95,7 @@ def test_read_config_secure_permissions(
     mock_stat.assert_called_once_with("config.yaml")
 
 
+@patch("cf_ips_to_hcloud_fw.config.os.name", "posix")
 @patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
 @patch("cf_ips_to_hcloud_fw.config.os.stat")
 @patch("logging.error")

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.2.2.dev1"
+version = "1.3.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
## Summary

Add POSIX config permission validation to harden secret handling while preserving Docker/Kubernetes compatibility.

## What changed

- Reject config files writable by group/others on POSIX.
- Allow group/other read-only permissions (common with mounted Docker/Kubernetes secrets), but log a warning.
- Add targeted tests in `tests/test_config.py`.
- Document behavior in `README.md` and `CHANGELOG.md`.
- Bump development cycle to `v1.3.0` / `1.3.0.dev1`.

## Breaking change

Yes. Configs with group/other write bits that previously worked are now rejected.

## Validation

- `make` passed locally.
- Config tests pass with updated permission-path coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Config files with group/other write permissions are now rejected on POSIX systems.

* **New Features**
  * Added config file permission validation on POSIX systems; warns on permissive read access but supports Docker/Kubernetes read-only secret mounts.
  * Upgraded Docker build provenance attestations to stable SLSA v1 schema.

* **Documentation**
  * Added POSIX config file permission best practices guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->