### PR TITLE
test(config): add permission and no-secret logging coverage

### DIFF
--- a/src/cf_ips_to_hcloud_fw/config.py
+++ b/src/cf_ips_to_hcloud_fw/config.py
@@ -67,7 +67,12 @@ def read_config(config_file: str) -> list[Project]:
     try:
         projects = TypeAdapter(list[Project]).validate_python(config)
     except ValidationError as e:
-        log_error_and_exit(f"Config file {config_file!r} is broken: {e}")
+        sanitized_errors = e.errors(
+            include_url=False,
+            include_context=False,
+            include_input=False,
+        )
+        log_error_and_exit(f"Config file {config_file!r} is broken: {sanitized_errors}")
 
     if not projects:
         logging.warning(f"Config file {config_file!r} contains no projects - exiting")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,6 +68,31 @@ def test_read_config_permissive_read_permissions_warn(
     )
 
 
+@patch("cf_ips_to_hcloud_fw.config.os.name", "nt")
+@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
+@patch("cf_ips_to_hcloud_fw.config.os.stat")
+@patch(
+    "builtins.open",
+    mock_open(
+        read_data="""
+- token: token
+  firewalls:
+    - fw-1
+""",
+    ),
+)
+def test_read_config_permission_check_skipped_on_non_posix(
+    mock_stat: MagicMock,
+    mock_exists: MagicMock,
+) -> None:
+    """Skip POSIX-only permission checks on non-POSIX systems."""
+    projects = read_config("config.yaml")
+
+    assert projects == [Project(token=SecretStr("token"), firewalls=["fw-1"])]
+    mock_exists.assert_not_called()
+    mock_stat.assert_not_called()
+
+
 @patch("cf_ips_to_hcloud_fw.config.os.name", "posix")
 @patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
 @patch("cf_ips_to_hcloud_fw.config.os.stat")
@@ -295,3 +320,28 @@ def test_read_config_missing_firewalls_rejected(mock_logging: MagicMock) -> None
     assert "Config file 'config.yaml' is broken:" in error_msg
     assert "firewalls" in error_msg.lower()
     assert "required" in error_msg.lower() or "missing" in error_msg.lower()
+
+
+@patch("cf_ips_to_hcloud_fw.config.os.name", "nt")
+@patch(
+    "builtins.open",
+    mock_open(
+        read_data="""
+- token: SUPER_SECRET_TOKEN_VALUE
+  firewalls: []
+""",
+    ),
+)
+@patch("logging.error")
+def test_read_config_validation_error_redacts_secret_value(
+    mock_logging: MagicMock,
+) -> None:
+    """Validation error logs must not include raw token values."""
+    with pytest.raises(SystemExit) as e:
+        read_config("config.yaml")
+
+    assert e.value.code == 1
+    mock_logging.assert_called_once()
+    error_msg = mock_logging.call_args[0][0]
+    assert "Config file 'config.yaml' is broken:" in error_msg
+    assert "SUPER_SECRET_TOKEN_VALUE" not in error_msg


### PR DESCRIPTION
## Summary

Add focused tests for config permission enforcement behavior and no-secret logging guarantees.

## What changed

- Added a non-POSIX test to verify permission checks are skipped on non-POSIX systems.
- Added a validation-error logging test to ensure raw token values are not leaked.
- Updated config validation error handling to log sanitized Pydantic errors (`include_input=False`, `include_context=False`, `include_url=False`).

## Why

This keeps permission enforcement tests deterministic across runners and strengthens secret hygiene in error logs.

## Validation

- Ran `tests/test_config.py` and `tests/test_logging.py`.
- Result: 19 passed, 0 failed.
