### PR TITLE
chore(deps-dev): bump pyright, ruff, and ty minimum versions

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -63,10 +63,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pyright", specifier = ">=1.1.409" },
+    { name = "pyright", specifier = ">=1.1.410" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = ">=0.15.15" },
-    { name = "ty", specifier = ">=0.0.40" },
+    { name = "ruff", specifier = ">=0.15.16" },
+    { name = "ty", specifier = ">=0.0.44" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `pyright` minimum version from `>=1.1.409` to `>=1.1.410`
- Bumps `ruff` minimum version from `>=0.15.15` to `>=0.15.16`
- Bumps `ty` minimum version from `>=0.0.40` to `>=0.0.44`

## Test plan

- [ ] CI passes (lint + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)