### PR TITLE
chore(pre-commit): add uv-lock check hook and bump ruff to v0.15.16

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,13 @@ repos:
       - id: check-toml
       - id: pretty-format-json
         args: [--autofix, --indent=4]
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: c665864e22f27255a10d82e14f8ccea6843fd65e  # frozen: 0.11.19
+    hooks:
+      - id: uv-lock
+        args: [--check]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 0671d8ab202c4ac093b78433ae5baf74f3fc7246  # frozen: v0.15.15
+    rev: 22f0422809455ec89ffdcf5a00170ba816e42ddb  # frozen: v0.15.16
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
## Summary

- Adds a `uv-lock --check` hook from `astral-sh/uv-pre-commit` to ensure the lock file stays in sync with `pyproject.toml` on every commit.
- Bumps ruff from `v0.15.15` to `v0.15.16`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration and code quality check dependencies for the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->