### PR TITLE
chore(vscode): add ty extension and clean up Pylance settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,11 @@
 {
     "recommendations": [
-        "davidanson.vscode-markdownlint",
-        "yzhang.markdown-all-in-one",
-        "ms-python.vscode-pylance",
-        "ms-python.python",
-        "github.vscode-github-actions",
+        "astral-sh.ty",
         "charliermarsh.ruff",
-        "tamasfe.even-better-toml"
+        "davidanson.vscode-markdownlint",
+        "github.vscode-github-actions",
+        "ms-python.python",
+        "tamasfe.even-better-toml",
+        "yzhang.markdown-all-in-one"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,12 +22,6 @@
         "editor.defaultFormatter": "redhat.vscode-yaml",
         "editor.formatOnSave": true
     },
-    "python.analysis.autoFormatStrings": true,
-    "python.analysis.autoImportCompletions": true,
-    "python.analysis.inlayHints.callArgumentNames": "partial",
-    "python.analysis.inlayHints.functionReturnTypes": true,
-    "python.analysis.inlayHints.pytestParameters": true,
-    "python.analysis.inlayHints.variableTypes": true,
     "python.missingPackage.severity": "Error",
     "python.testing.pytestArgs": [
         "--no-cov"


### PR DESCRIPTION
## Summary

Updates the VS Code workspace configuration to use `astral-sh.ty` as the type checker and removes now-redundant Pylance-specific settings.

### Changes

- Add `astral-sh.ty` to recommended extensions
- Sort extensions list alphabetically
- Remove Pylance-specific analysis settings (`autoFormatStrings`, `autoImportCompletions`, `inlayHints.*`) as ty handles these

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VS Code recommended extensions list for improved development experience
  * Simplified VS Code Python configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->