### PR TITLE
chore: replace pyright with ty for type checking

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,7 @@
 - First bootstrap: `make venv` (calls `uv sync`, creates `.venv/`, installs
   default + dev groups from `uv.lock`). Later targets refresh the environment when
   the lock or `pyproject.toml` changes.
-- Default loop: `make lint` (ruff + ty + pyright) → `make test` (pytest,
+- Default loop: `make lint` (ruff + ty) → `make test` (pytest,
   coverage≥80, writes `coverage.xml` + `htmlcov/`) → `make build` (`uv build`).
   `make` runs all three.
 - `make clean` wraps `git clean -xdf`; it nukes `.venv/` and every untracked
@@ -47,7 +47,7 @@
 
 ## CI & Quality Gates
 
-- `python-package.yaml` runs the uv sync / lint (ruff, ty, pyright) / test /
+- `python-package.yaml` runs the uv sync / lint (ruff, ty) / test /
   build steps directly on CPython 3.10–3.14, uploads coverage, SBOM, and
   attestations.
 - `docker.yaml` performs multi-arch builds, security scans (Docker Scout + Grype),

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -97,9 +97,6 @@ jobs:
       - name: Type check (ty)
         run: uv run --no-sync ty check
 
-      - name: Type check (pyright)
-        run: uv run --no-sync pyright
-
       - name: Test
         run: uv run --no-sync pytest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - **Breaking:** Added POSIX config-permission checks that reject group/other
   writable config files while allowing common read-only Docker/Kubernetes
   secret mounts with a warning
+- Replaced `pyright` with `ty` for type checking in the lint pipeline and
+  removed the `ms-python.vscode-pylance` VS Code extension recommendation
 - Start new development cycle
 
 ## [v1.2.1] – 2026-05-30

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,8 @@ RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/
     --mount=target=pyproject.toml,source=/pyproject.toml \
     --mount=target=uv.lock,source=/uv.lock \
     --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-    --mount=type=cache,id=npm,target=/root/.npm <<EOF
-    set -eux
+    --mount=type=cache,id=npm,target=/root/.npm \
     uv sync --link-mode copy --group dev --frozen --no-install-project
-    uv run --no-project pyright --version
-EOF
 
 # Lint, test and build using the synced environment
 RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/local/bin/uv \
@@ -33,7 +30,6 @@ RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/
     uv sync --link-mode copy --group dev --frozen
     uv run --no-sync ruff check --output-format=github
     uv run --no-sync ty check
-    uv run --no-sync pyright
     uv run --no-sync pytest
     uv build
 EOF

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ sync: $(SYNC_STAMP)
 lint: $(SYNC_STAMP)
 	$(UV) run $(UV_SYNC_FLAGS) ruff check
 	$(UV) run $(UV_SYNC_FLAGS) ty check
-	$(UV) run $(UV_SYNC_FLAGS) pyright
 
 .PHONY: test
 test: $(SYNC_STAMP)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ PyPI = "https://pypi.org/project/cf-ips-to-hcloud-fw/"
 
 [dependency-groups]
 dev = [
-    "pyright>=1.1.410",
     "pytest-cov>=7.1.0",
     "ruff>=0.15.16",
     "ty>=0.0.44",
@@ -76,14 +75,7 @@ addopts = [
 ]
 
 [tool.coverage.run]
-core = "ctrace" # test_config.py doesn't work with sysmon and python 3.14 yet
-
-[tool.pyright]
-include = ["src", "tests"]
-strict = ["src", "tests"]
-reportMissingImports = true
-reportMissingTypeStubs = true
-venv = ".venv"
+core = "ctrace" # test_config.py does not work with sysmon and python 3.14 yet
 
 [tool.ruff]
 src = ["src"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,6 +32,6 @@ def test_project_extra_field_rejected() -> None:
         Project(
             token=SecretStr("my-token"),
             firewalls=["fw-1"],
-            unknown_field="value",  # pyright: ignore[reportCallIssue] # ty: ignore[unknown-argument]
+            unknown_field="value",  # ty: ignore[unknown-argument]
         )
     assert "Extra inputs are not permitted" in str(e.value)

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "pyright" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "ty" },
@@ -63,7 +62,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pyright", specifier = ">=1.1.410" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.15.16" },
     { name = "ty", specifier = ">=0.0.44" },
@@ -408,15 +406,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -572,19 +561,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pyright"
-version = "1.1.410"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Removes `pyright` from the project and fully adopts `ty` (from Astral) as the sole type checker.

## Changes

- Remove `pyright` from dev dependencies and `pyproject.toml` configuration
- Remove pyright lint step from `Makefile`, CI workflow (`python-package.yaml`), and `Dockerfile`
- Remove `# pyright: ignore` comment from `tests/test_models.py`
- Update `copilot-instructions.md` to reflect the updated lint pipeline (`ruff + ty`)
- Add CHANGELOG entry for the tooling switch