### PR TITLE
chore: remove npm cache mounts and network allowlist entries

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -62,7 +62,6 @@ jobs:
             quay.io:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443
-            registry.npmjs.org:443
             registry.scout.docker.com:443
             rekor.sigstore.dev:443
             release-assets.githubusercontent.com:443

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -70,7 +70,6 @@ jobs:
             objects.githubusercontent.com:443
             pypi.org:443
             raw.githubusercontent.com:443
-            registry.npmjs.org:443
             rekor.sigstore.dev:443
             release-assets.githubusercontent.com:443
             releases.astral.sh:443

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/
     --mount=target=pyproject.toml,source=/pyproject.toml \
     --mount=target=uv.lock,source=/uv.lock \
     --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-    --mount=type=cache,id=npm,target=/root/.npm \
     uv sync --link-mode copy --group dev --frozen --no-install-project
 
 # Lint, test and build using the synced environment
@@ -24,8 +23,7 @@ RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/
     --mount=target=pyproject.toml,source=/pyproject.toml \
     --mount=target=uv.lock,source=/uv.lock \
     --mount=target=README.md,source=/README.md \
-    --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
-    --mount=type=cache,id=npm,target=/root/.npm <<EOF
+    --mount=type=cache,id=uv-cache,target=/root/.cache/uv <<EOF
     set -eux
     uv sync --link-mode copy --group dev --frozen
     uv run --no-sync ruff check --output-format=github


### PR DESCRIPTION
## Summary

Cleans up npm remnants that were only needed by `pyright` (removed in #1250).

## Changes

- Remove `--mount=type=cache,id=npm,target=/root/.npm` from both `RUN` stages in `Dockerfile`
- Drop `registry.npmjs.org:443` from the egress allowlists in `docker.yaml` and `python-package.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build workflow configurations to refine security settings and dependencies for deployment processes.
  * Optimized container build process to streamline compilation steps and reduce build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->