### PR TITLE
chore: add cross-agent skills, PR-feedback prompt, and CLAUDE.md

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: cut-release
+description: 'Cut a new release of cf-ips-to-hcloud-fw. Use when asked to release, cut a release, bump the version, tag a release, ship a version, or publish to PyPI/Docker. Bumps the version in pyproject.toml, finalizes the CHANGELOG entry, builds locally, commits (DCO sign-off + GPG-signed), creates a signed annotated v* tag, and pushes so CI builds, signs, and publishes to PyPI/Docker and drafts the GitHub release.'
+argument-hint: 'Target version (e.g. 1.3.0) or bump type (major/minor/patch)'
+---
+
+# Cut a Release
+
+Releases are **tag-driven**: pushing a `v*` tag triggers CI
+(`python-package.yaml` + `docker.yaml`) to build, lint, test, sign, publish to
+PyPI + TestPyPI, build multi-arch Docker images, and **draft** a GitHub release.
+Your job here is the local prep (via a PR, since `main` is protected) + the tag.
+
+## When to Use
+
+- "Release 1.3.0", "cut a release", "bump the version and tag"
+- "Ship a new version", "publish to PyPI"
+
+## Prerequisites (verify, don't assume)
+
+- Clean working tree, and `main` up to date with `origin/main`.
+- **`main` is protected: direct pushes are rejected.** All commits (the release
+  bump and the post-release dev-cycle bump) MUST land via a PR that is merged.
+  Only the tag is pushed directly to a ref.
+- Commit/tag signing configured (this repo requires verified signatures + DCO).
+  Check `git config --get commit.gpgsign`; tags are signed with `git tag -s`.
+- `gh` CLI authenticated (used to open the PR and view/publish the draft release).
+
+## Procedure
+
+### 1. Determine the target version
+
+Read the current version:
+
+```bash
+grep '^version = ' pyproject.toml
+```
+
+- The dev version looks like `1.3.0.dev1` → the release version is `1.3.0`.
+- Otherwise apply the requested bump (`major`/`minor`/`patch`) per SemVer.
+- Confirm the chosen version with the user if it isn't explicit.
+
+### 2. Pre-flight checks
+
+```bash
+git switch main && git pull --ff-only
+git status                      # must be clean
+make lint && make test          # gates must pass
+```
+
+### 3. Bump the version
+
+Edit `pyproject.toml` `version = "..."` to the release version (drop any
+`.devN` suffix). This is the single source of truth (`uv_build` reads it).
+
+### 4. Finalize the CHANGELOG
+
+In `CHANGELOG.md`, update the top entry:
+
+- Change `## [vX.Y.Z] – Unreleased` to `## [vX.Y.Z] – YYYY-MM-DD` (today's date).
+- Ensure the bullets accurately describe user-facing changes since the last tag.
+  Cross-check with `git --no-pager log --oneline vLAST..HEAD`.
+- Mark breaking changes with a leading `**Breaking:**` and security items with
+  `**Security:**`, matching existing style.
+- Keep prose wrapped at ~100 cols (repo Markdown style); don't reflow code/URLs.
+
+### 4b. Bump the pinned version in docs/templates
+
+Several files reference the previous **released** version (not `.devN`) and must
+be bumped to the new `X.Y.Z`:
+
+- `README.md` — the pinned Docker image tag examples
+  (e.g. `jkreileder/cf-ips-to-hcloud-fw:X.Y.Z`, the `- \`X.Y.Z\`: ...` bullet,
+  the Kubernetes `image:` line) and the attestation example `VERSION=X.Y.Z`.
+- `.github/ISSUE_TEMPLATE/bug_report.md` — the example version
+  `- cf-ips-to-hcloud-fw version: [e.g. X.Y.Z]`.
+
+Find every occurrence of the old release version to be thorough (the `:latest`
+and `:main` tags stay as-is — only the pinned numeric tag changes):
+
+```bash
+git --no-pager grep -n "<old-version>" -- README.md .github/ISSUE_TEMPLATE/bug_report.md
+```
+
+If you renamed/added/removed a README section, also update the manually
+maintained table of contents.
+
+### 5. Build locally (sanity check)
+
+```bash
+make build      # rm -rf dist && uv build
+ls dist         # expect a wheel + sdist for the new version
+```
+
+### 6. Open the release PR (the bump cannot go straight to `main`)
+
+`main` is protected, so commit on a branch and open a PR:
+
+```bash
+git switch -c release/vX.Y.Z
+git add pyproject.toml CHANGELOG.md README.md .github/ISSUE_TEMPLATE/bug_report.md
+git commit -s -S -m "chore(release): vX.Y.Z"
+git push -u origin release/vX.Y.Z
+gh pr create --base main --title "chore(release): vX.Y.Z" \
+  --body "Release vX.Y.Z. Bumps version and finalizes the changelog."
+```
+
+Use the `ship-changes` skill for this if you prefer. Wait for required checks,
+get the PR merged, then continue.
+
+### 7. Tag the merged release commit
+
+After the PR is merged, update `main` and tag the merge result. The tagged
+commit must be the one carrying the release version in `pyproject.toml`.
+
+```bash
+git switch main && git pull --ff-only
+grep '^version = ' pyproject.toml      # confirm it shows X.Y.Z
+git tag -s vX.Y.Z -m "vX.Y.Z"
+git --no-pager tag -v vX.Y.Z           # verify signature
+```
+
+### 8. Push the tag
+
+Tag refs are not blocked by the branch protection on `main`, so the tag can be
+pushed directly:
+
+```bash
+git push origin vX.Y.Z
+```
+
+Pushing the tag starts the publish pipeline. Report the Actions URL:
+`https://github.com/jkreileder/cf-ips-to-hcloud-fw/actions`.
+
+> If pushing the tag is also rejected, the tag must be created via a release on
+> the merged commit instead — pause and tell the user; do not force anything.
+
+### 9. Publish the draft release
+
+CI creates a **draft** GitHub release with provenance/SBOM/attestations.
+Once the workflows succeed, review and publish it:
+
+```bash
+gh release view vX.Y.Z
+gh release edit vX.Y.Z --draft=false   # after verifying notes & assets
+```
+
+### 10. Start the next dev cycle (via a second PR)
+
+Once the release is published, open another PR (again, not a direct push to
+`main`): bump `pyproject.toml` to the next dev version (e.g. `1.4.0.dev1`) and
+add a fresh `## [vNEXT] – Unreleased` heading at the top of `CHANGELOG.md` with
+a `- Start new development cycle` bullet.
+
+```bash
+git switch -c chore/start-vNEXT-dev-cycle
+# edit pyproject.toml + CHANGELOG.md
+git commit -s -S -am "chore: start new development cycle"
+git push -u origin chore/start-vNEXT-dev-cycle
+gh pr create --base main --title "chore: start new development cycle" \
+  --body "Begin vNEXT development."
+```
+
+Merge it (use the `ship-changes` skill if helpful).
+
+## Completion Checklist
+
+- [ ] `pyproject.toml` version set to the release version (no `.devN`).
+- [ ] CHANGELOG top entry dated and accurate.
+- [ ] Pinned version bumped in `README.md` and
+      `.github/ISSUE_TEMPLATE/bug_report.md` (no stale old version remains).
+- [ ] `make lint` and `make test` pass; `make build` produced dist artifacts.
+- [ ] Release bump landed via a **merged PR** (not a direct push to `main`).
+- [ ] Release commit is signed-off + GPG-signed.
+- [ ] Annotated tag `vX.Y.Z` created on the merged commit, GPG-signed, verifies.
+- [ ] Tag pushed; publish workflows green.
+- [ ] Draft GitHub release reviewed and published.
+- [ ] Next dev cycle started via a **second merged PR**
+      (`pyproject.toml` + `CHANGELOG.md`).
+
+## Gotchas
+
+- `main` is protected — direct pushes are rejected. Both the release bump and
+  the dev-cycle bump go through PRs; only the tag is pushed directly.
+- Never publish PyPI manually — CI owns publishing on tag push.
+- Tag the **merged** release commit, so the tagged tree's `pyproject.toml`
+  version (`X.Y.Z`) matches the tag (`vX.Y.Z`).
+- Branch protection rejects unsigned commits/tags; ensure signing works first.

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -79,8 +79,11 @@ Find every occurrence of the old release version to be thorough (the `:latest`
 and `:main` tags stay as-is — only the pinned numeric tag changes):
 
 ```bash
-git --no-pager grep -n "<old-version>" -- README.md .github/ISSUE_TEMPLATE/bug_report.md
+git --no-pager grep -nF "<old-version>" -- README.md .github/ISSUE_TEMPLATE/bug_report.md
 ```
+
+`-F` matches the version literally — without it the dots in `1.2.3` are regex
+wildcards and can overmatch.
 
 If you renamed/added/removed a README section, also update the manually
 maintained table of contents.
@@ -110,14 +113,16 @@ get the PR merged, then continue.
 
 ### 7. Tag the merged release commit
 
-After the PR is merged, update `main` and tag the merge result. The tagged
-commit must be the one carrying the release version in `pyproject.toml`.
+After the PR is merged, tag **the exact merge commit** — don't just tag whatever
+`main` points at, since another PR could land in the meantime and advance `main`
+past the release. Capture the release PR's merge SHA and tag that commit.
 
 ```bash
-git switch main && git pull --ff-only
-grep '^version = ' pyproject.toml      # confirm it shows X.Y.Z
-git tag -s vX.Y.Z -m "vX.Y.Z"
-git --no-pager tag -v vX.Y.Z           # verify signature
+release_sha="$(gh pr view <release-pr-number> --json mergeCommit --jq .mergeCommit.oid)"
+git fetch origin
+git show "$release_sha:pyproject.toml" | grep '^version = '   # confirm X.Y.Z
+git tag -s vX.Y.Z "$release_sha" -m "vX.Y.Z"
+git --no-pager tag -v vX.Y.Z                                  # verify signature
 ```
 
 ### 8. Push the tag

--- a/.claude/skills/ship-changes/SKILL.md
+++ b/.claude/skills/ship-changes/SKILL.md
@@ -125,9 +125,11 @@ Fill the repo's PR template, but keep it lean and honest:
 
 - Write the prose sections (Description, Motivation, Changes Made) accurately.
 - **Don't pre-tick the template's checkboxes.** Those are the *author's*
-  self-certification, and GitHub already verifies the DCO sign-off, signature,
-  and Conventional Commits title — so leave the boxes unchecked for the human to
-  confirm rather than asserting them on their behalf.
+  self-certification. The DCO sign-off and the commit signature are already
+  enforced (DCO app + branch protection); the Conventional Commits title is a
+  repo convention you should follow but nothing verifies it automatically.
+  Either way, leave the boxes unchecked for the human to confirm rather than
+  asserting them on their behalf.
 - Report what you actually ran in prose under Testing (e.g. "`make check` —
   56 passed, 100% coverage") instead of ticking boxes.
 - Drop sections that don't apply rather than padding them.

--- a/.claude/skills/ship-changes/SKILL.md
+++ b/.claude/skills/ship-changes/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: ship-changes
+description: 'Ship the current working-tree changes as a pull request. Use when asked to commit and push, open a PR, ship/submit changes, create a feature branch and PR, or "make a PR for this". Creates a feature branch if on the default branch, crafts a Conventional Commits message, commits with DCO sign-off and GPG signing, pushes, and opens a GitHub PR with a Conventional Commits title.'
+argument-hint: 'Optional: PR type/scope, target branch, or extra context for the commit/PR'
+---
+
+# Ship Changes as a Pull Request
+
+Take the current changes from working tree to an open GitHub pull request:
+branch → gates (`make check`) → commit (signed-off + GPG-signed) → push → PR.
+
+## When to Use
+
+- "Commit and push this", "open a PR", "ship these changes", "submit this"
+- "Create a feature branch and PR for this"
+- After finishing a unit of work that should become a pull request
+
+## Prerequisites (verify, don't assume)
+
+- `gh` CLI is installed and authenticated (`gh auth status`). If missing, fall
+  back to pushing and printing the compare URL instead of `gh pr create`.
+- Commit signing is configured. This repo policy requires **both**:
+  - DCO sign-off via `git commit -s` (adds `Signed-off-by:`)
+  - GPG/SSH signature (verified signatures). Check
+    `git config --get commit.gpgsign`; if not `true`, pass `-S` explicitly.
+
+## Procedure
+
+### 1. Inspect the changes
+
+```bash
+git status
+git --no-pager diff --stat HEAD
+git branch --show-current
+```
+
+Read the actual diff (`git --no-pager diff HEAD`) enough to understand what
+changed — you need this to pick the right Conventional Commit `type`/`scope` and
+write an accurate message. Never invent changes you didn't verify.
+
+### 2. Decide the branch
+
+- **On the default branch** (`main`): create a feature branch. Derive the name
+  from the change: `<type>/<short-kebab-summary>` (e.g. `fix/firewall-rule-sync`,
+  `chore/bump-ruff`).
+
+  ```bash
+  git switch -c <branch-name>
+  ```
+
+- **Already on a feature branch**: check whether the branch name AND existing
+  commits fit the new changes.
+  - If they fit → stay and add a commit.
+  - If the branch name is now misleading (e.g. named `fix/x` but the work became
+    a feature) → ask the user whether to rename
+    (`git branch -m <new-name>`) or create a new branch. Do not silently rename a
+    pushed branch.
+
+### 3. Stage
+
+Stage the relevant changes. Prefer explicit paths over `git add -A` when only a
+subset is intended. Confirm with the user if it's ambiguous which files belong
+to this change.
+
+```bash
+git add <paths>   # or: git add -A
+```
+
+### 4. Run the quality gates
+
+Before committing, mirror what CI enforces so failures are caught locally:
+
+```bash
+make check       # make lint (ruff + ty) then make test (pytest, coverage ≥ 80%)
+```
+
+Fix anything that fails before continuing — for lint, prefer
+`uv run ruff check --fix` / `uv run ruff format`; for `ty` errors fix the
+annotations rather than suppressing; for coverage below 80%, add tests under
+`tests/`. (`pre-commit` also runs ruff/gitleaks/markdownlint on commit.)
+
+### 5. Craft the commit message (Conventional Commits)
+
+Format: `<type>[optional scope]: <description>`
+
+- **type**: `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`,
+  `build`, `ci`, `style`, `revert`.
+- **scope**: optional, lowercase, matches the area touched (e.g. `firewall`,
+  `cloudflare`, `config`, `deps`, `ci`, `docker`).
+- **description**: imperative mood, lowercase start, no trailing period,
+  ≤ ~72 chars on the subject line.
+- Add a body (blank line then prose, wrapped ~72 cols) when the *why* isn't
+  obvious from the subject. Add `Fixes #<n>` / `Closes #<n>` footers when an
+  issue applies.
+
+Examples: `fix(firewall): resolve rule sync issue`,
+`chore(deps): bump ruff to v0.14.6`, `ci(docker): pin scout action version`.
+
+### 6. Commit (sign-off + GPG-signed)
+
+```bash
+git commit -s -S -m "<type>(<scope>): <subject>" [-m "<body>"]
+```
+
+- `-s` adds the DCO `Signed-off-by:` line (required).
+- `-S` GPG-signs the commit. If `commit.gpgsign` is already `true` you may omit
+  `-S`, but passing it is harmless and explicit.
+- After committing, verify: `git --no-pager log --show-signature -1` shows a
+  `Signed-off-by:` line and a good signature.
+
+### 7. Push
+
+```bash
+git push -u origin <branch-name>
+```
+
+If the branch was already pushed, a plain `git push` is enough (use
+`--force-with-lease` only if you intentionally rewrote history and the user
+agreed).
+
+### 8. Open the pull request
+
+Use a Conventional Commits **PR title** (same format as the commit subject).
+Fill the repo's PR template, but keep it lean and honest:
+
+- Write the prose sections (Description, Motivation, Changes Made) accurately.
+- **Don't pre-tick the template's checkboxes.** Those are the *author's*
+  self-certification, and GitHub already verifies the DCO sign-off, signature,
+  and Conventional Commits title — so leave the boxes unchecked for the human to
+  confirm rather than asserting them on their behalf.
+- Report what you actually ran in prose under Testing (e.g. "`make check` —
+  56 passed, 100% coverage") instead of ticking boxes.
+- Drop sections that don't apply rather than padding them.
+
+```bash
+gh pr create \
+  --base main \
+  --title "<type>(<scope>): <subject>" \
+  --body "$(cat <<'EOF'
+## Description
+<summary>
+
+## Changes Made
+- <change 1>
+- <change 2>
+
+## Testing
+<what you ran and the result, e.g. `make check` — 56 passed, 100% coverage>
+EOF
+)"
+```
+
+If `gh` is unavailable or PR creation fails, print the push result and the
+compare URL: `https://github.com/jkreileder/cf-ips-to-hcloud-fw/compare/main...<branch>`.
+
+## Completion Checklist
+
+- [ ] On a feature branch (never committed straight to `main`).
+- [ ] Commit message is valid Conventional Commits, accurately describes the diff.
+- [ ] Commit has a `Signed-off-by:` line (DCO) and a verified GPG/SSH signature.
+- [ ] Branch pushed to `origin`.
+- [ ] PR opened with a Conventional Commits title and a filled-out body.
+- [ ] Reported the PR URL back to the user.
+
+## Notes & Gotchas
+
+- This repo enforces verified signatures and DCO via branch protection — an
+  unsigned or un-signed-off commit will be rejected on push/merge.
+- Don't reflow or reformat unrelated code just to commit; commit only the
+  intended change.
+- PR titles, like commits, must follow Conventional Commits (repo policy).

--- a/.github/prompts/address-pr-feedback.prompt.md
+++ b/.github/prompts/address-pr-feedback.prompt.md
@@ -1,0 +1,36 @@
+---
+description: 'Address review feedback on the active cf-ips-to-hcloud-fw pull
+request, then commit fixes with DCO sign-off + GPG signing and push.'
+name: 'Address PR Feedback'
+argument-hint: 'Optional: specific comment, reviewer, or area to focus on'
+agent: 'agent'
+---
+<!-- markdownlint-disable-file MD041 -->
+
+Address the review feedback on the current pull request for this repository.
+
+1. Gather the open review comments and CI/check failures on the active PR. Use
+   the VS Code GitHub Pull Requests `address-pr-comments` tool if it's available;
+   otherwise fall back to `gh` (`gh pr view --comments`, `gh api` for review
+   threads). If a specific reviewer, thread, or area was named in the argument,
+   focus there first.
+2. For each actionable comment, make the change in the codebase. Follow existing
+   patterns; keep edits scoped to what the comment asks — don't reflow unrelated
+   code.
+3. Before committing, run the quality gates with `make check` (`make lint` then
+   `make test`, coverage ≥ 80%). Fix anything that fails.
+4. Commit the fixes with a Conventional Commits message that references the
+   feedback, using **DCO sign-off and GPG signing** (repo policy requires both):
+   `git commit -s -S -m "<type>(<scope>): address review feedback"`.
+   Group related fixes; use separate commits if changes are logically distinct.
+5. Push to the PR branch (`git push`). Do not force-push unless history was
+   intentionally rewritten and the user agreed.
+6. Reply to / resolve the addressed review threads where appropriate, and post a
+   concise summary comment of what changed. Report back which comments were
+   addressed and which (if any) need the author's decision.
+
+Constraints:
+
+- Keep PR title/commits in Conventional Commits format.
+- Never bypass signing or sign-off.
+- If a comment is ambiguous or you disagree, ask the user instead of guessing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# cf-ips-to-hcloud-fw
+
+Project instructions are maintained in a single tool-neutral file so Claude Code
+and GitHub Copilot stay in sync. The import below pulls it in.
+
+@.github/copilot-instructions.md


### PR DESCRIPTION
## Description

Adds agent tooling shared by **Claude Code** and **GitHub Copilot**. Both
assistants discover skills under `.claude/skills/`, so one location serves both.
No application code changes.

## Motivation

Encode this repo's non-obvious workflows (signed PRs, the tag-driven release
ritual) and project instructions once, in a tool-neutral way, instead of
re-deriving them each session.

## Changes Made

- `.claude/skills/ship-changes/` — runbook for taking working-tree changes to a
  DCO-signed, GPG-signed PR (branch → `make check` gates → commit → push → PR),
  including guidance to fill the PR template without pre-ticking the author's
  checkboxes.
- `.claude/skills/cut-release/` — runbook for the tag-driven release flow
  (version/CHANGELOG bump via PR, signed tag, publish the draft release).
- `.github/prompts/address-pr-feedback.prompt.md` — Copilot prompt for working
  through PR review feedback; uses the VS Code GitHub PR tool when available and
  falls back to `gh`.
- `CLAUDE.md` — imports `.github/copilot-instructions.md` so project
  instructions live in one tool-neutral file.

## Testing

`make check` — ruff + ty clean, 56 passed, 100% coverage. pre-commit (markdownlint) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized release procedure documentation for versioning and tagging workflow.
  * Added GitHub pull request workflow documentation for shipping changes.
  * Added prompt template for addressing pull request feedback.
  * Updated project instructions reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->