### PR TITLE
chore: run pre-commit lint from the venv and tidy the Makefile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autofix_prs: false
   autoupdate_commit_msg: "chore(deps): update pre-commit repo revisions"
+  skip: [ruff-check, ruff-format, ty]  # need uv/venv; CI runs `make lint` (ruff + ty) instead
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -16,16 +17,35 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: c665864e22f27255a10d82e14f8ccea6843fd65e  # frozen: 0.11.19
+    rev: fe063293315003e95dff96d43c4928f8799a5c62  # frozen: 0.11.21
     hooks:
       - id: uv-lock
         args: [--check]
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 22f0422809455ec89ffdcf5a00170ba816e42ddb  # frozen: v0.15.16
+  # ruff and ty run from the project venv (uv.lock) for parity with `make lint`
+  # and CI — the locked versions are the single source of truth. ruff in
+  # particular runs with `preview = true`, whose rules/formatting are
+  # version-sensitive, so an independently pinned hook could disagree with CI.
+  - repo: local
     hooks:
       - id: ruff-check
-        args: [--fix, --exit-non-zero-on-fix]
+        name: ruff check
+        entry: uv run ruff check --fix --exit-non-zero-on-fix
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
       - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
+      - id: ty
+        name: ty check
+        entry: uv run ty check
+        language: system
+        types: [python]
+        pass_filenames: false
+        require_serial: true
   - repo: https://github.com/gitleaks/gitleaks
     rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e  # frozen: v8.30.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ SHELL := bash
 
 UV := uv
 VENV := .venv
-BIN := $(VENV)/bin
 SYNC_STAMP := $(VENV)/.uv-synced
 
 UV_SYNC_FLAGS := --group dev --frozen
+UV_RUN_FLAGS := --no-sync   # env is already synced via $(SYNC_STAMP); don't re-check
 
 .PHONY: all
 all: lint test build
@@ -27,12 +27,12 @@ sync: $(SYNC_STAMP)
 
 .PHONY: lint
 lint: $(SYNC_STAMP)
-	$(UV) run $(UV_SYNC_FLAGS) ruff check
-	$(UV) run $(UV_SYNC_FLAGS) ty check
+	$(UV) run $(UV_RUN_FLAGS) ruff check
+	$(UV) run $(UV_RUN_FLAGS) ty check
 
 .PHONY: test
 test: $(SYNC_STAMP)
-	$(UV) run $(UV_SYNC_FLAGS) pytest
+	$(UV) run $(UV_RUN_FLAGS) pytest
 
 .PHONY: check
 check: lint test
@@ -49,4 +49,4 @@ upgrade-deps:
 
 .PHONY: clean
 clean:
-	git clean -xdf
+	git clean -xdf -e /config.yaml   # hard reset, but keep local config.yaml (holds API tokens)


### PR DESCRIPTION
## Description

Aligns local developer tooling with what CI actually runs, plus a couple of
Makefile tidy-ups. No application code changes.

## Changes Made

- **pre-commit**: run `ruff-check`, `ruff-format`, and `ty` as local hooks via
  `uv run`, dropping the upstream `ruff-pre-commit` repo. The versions in
  `uv.lock` become the single source of truth for pre-commit, `make lint`, and
  CI — important because ruff runs with `preview = true`, whose behaviour is
  version-sensitive, so an independently pinned hook could disagree with CI.
  These need a venv, so they're on the pre-commit.ci `skip` list (CI's
  `make lint` covers them). `uv-lock` stays on its upstream hook.
- **Makefile**: drop the unused `BIN` var; scope `make clean` with
  `-e /config.yaml` so a hard reset preserves the developer's gitignored,
  token-bearing config; add `--no-sync` to the lint/test `uv run` recipes since
  the sync stamp already guarantees a synced env (mirrors CI).

## Testing

`make check` — ruff + ty clean, 56 passed, 100% coverage. `prek run --all-files`
green (verified the relocated ruff/ty hooks run from the venv).