### PR TITLE
ci: add concurrency groups and job timeouts

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -13,10 +13,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze-python:
     name: Analyze Python code with CodeQL
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -83,6 +88,7 @@ jobs:
   analyze-actions:
     name: Analyze GitHub actions code with CodeQL
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -13,9 +13,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Harden runner

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -14,10 +14,16 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded PR/branch runs, but never cancel tag runs (they publish).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   docker:
     name: Docker build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -10,10 +10,18 @@ on:
 permissions:
   contents: read
 
+# workflow_run runs on the default-branch ref, so group by the *triggering*
+# run's branch — otherwise unrelated builds finishing together would cancel
+# each other's result publish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   publish-test-results:
     name: Publish test results
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
 
     permissions:

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -13,10 +13,16 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded PR/branch runs, but never cancel tag runs (they publish).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   upload-event-file:
     name: Upload event file
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -33,6 +39,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       id-token: write
@@ -185,6 +192,7 @@ jobs:
     needs:
       - provenance-and-draft-release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: test-pypi
       url: https://test.pypi.org/p/cf-ips-to-hcloud-fw
@@ -223,6 +231,7 @@ jobs:
       - provenance-and-draft-release
       - publish-to-test-pypi
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: pypi
       url: https://pypi.org/p/cf-ips-to-hcloud-fw
@@ -258,6 +267,7 @@ jobs:
     needs:
       - publish-to-pypi
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -15,10 +15,15 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -13,10 +13,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   trufflehog:
     name: Secret scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Harden runner


### PR DESCRIPTION
## Description

Adds two pieces of CI hygiene across all workflows: concurrency groups (so
superseded runs are cancelled) and per-job timeouts (so a hung job can't burn
the 360-minute default). No application code changes.

## Changes Made

- **Concurrency**, matched to each workflow's risk:
  - Tag-publishing (`python-package`, `docker`):
    `cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}` — cancels
    PR/branch runs but never a tag run mid-publish.
  - Read-only scanners (`codeql`, `dependency-review`, `scorecard`,
    `trufflehog`): plain `cancel-in-progress: true`.
  - `publish-test-results`: grouped by the triggering run's `head_branch`
    (its own `github.ref` is constant for `workflow_run` events).
- **`timeout-minutes`** on every job that can take one (5–45 min). The SLSA
  reusable-workflow jobs (`provenance-*`) are left as-is — `timeout-minutes`
  isn't valid on a job that calls another workflow via `uses:`.

## Testing

All eight workflow files parse cleanly (`yaml.safe_load`). Existing top-level
`permissions:` and SHA-pinned actions untouched.