### PR TITLE
docs(pr-template): trim redundant fields, add security prompt

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,17 +14,6 @@ and verify the checklist before submitting.
 
 <!-- Why are these changes needed? Link issues with "Fixes #<number>" if applicable -->
 
-## Type of Change
-
-<!-- Mark the relevant option(s) with an "x" -->
-
-- [ ] Bug fix (fixes #issue_number)
-- [ ] New feature (related to #issue_number)
-- [ ] Performance improvement
-- [ ] Dependency update
-- [ ] Documentation update
-- [ ] Other: ___________________
-
 ## Changes Made
 
 <!-- List the key changes in this PR -->
@@ -33,14 +22,17 @@ and verify the checklist before submitting.
 -
 -
 
+## Security
+
+<!-- Does this change how tokens/secrets are handled, or how firewall rules are
+computed or applied? Describe the impact, or write "None". -->
+
 ## Testing
 
-<!-- Describe how you tested these changes -->
+<!-- How did you test these changes? CI runs lint, type-check, and tests
+(≥80% coverage) on every PR, so no need to attest to those here. -->
 
 - [ ] Added or updated unit tests
-- [ ] All tests pass locally (`make test`)
-- [ ] Coverage maintained or improved (target: ≥80%)
-- [ ] Linting passes (`make lint`)
 
 ## Documentation
 
@@ -58,9 +50,3 @@ and verify the checklist before submitting.
      `<type>[optional scope]: <description>`
   - Example: `fix(firewall): resolve rule sync issue` or `chore(deps): bump ruff to v0.14.6`
 - [ ] Commits are signed off with `git commit -s` (required for DCO compliance)
-- [ ] No merge conflicts
-- [ ] Code follows project style (automatically checked via `make lint`)
-
-## Additional Notes
-
-<!-- Any additional context, screenshots, or notes? -->


### PR DESCRIPTION
## Description

Slims the PR template to the fields that need human judgment, and adds a
domain-relevant security prompt. The template had grown to ~13 checkboxes,
several of which restate things CI or GitHub already enforce.

## Changes Made

- **Testing**: dropped "tests pass locally", "coverage ≥80%", "linting passes"
  (all gated by CI); kept "added/updated unit tests".
- **Checklist**: dropped "no merge conflicts" (shown in the GitHub UI) and
  "code follows project style (via `make lint`)" (automated). Kept the DCO
  sign-off and Conventional Commits title reminders, which pre-empt a failing
  check before the contributor pushes.
- **Removed "Type of Change"**: the enforced Conventional Commits title already
  states the type, and the section's categories didn't map to the CC type set.
- **Removed "Additional Notes"** boilerplate.
- **Added "Security"**: a one-line prompt asking whether token/secret handling
  or firewall-rule logic is affected — relevant to this tool's domain.

Issue templates were left unchanged; they're already prose-only with no
redundant checkboxes.

## Security

None — documentation/template change only.

## Testing

`prek run markdownlint-cli2` on the template passes.