### PR TITLE
build: keep .claude/settings.local.json on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,4 @@ upgrade-deps:
 
 .PHONY: clean
 clean:
-	git clean -xdf -e /config.yaml   # hard reset, but keep local config.yaml (holds API tokens)
+	git clean -xdf -e /config.yaml -e /.claude/settings.local.json   # hard reset; keep local config.yaml (API tokens) and Claude settings


### PR DESCRIPTION
## Description

`make clean` (`git clean -xdf`) was deleting `.claude/settings.local.json` —
local Claude Code state (permission allowlist, etc.). It's ignored via a global
gitignore, and `-x` removes ignored files, so the hard reset wiped it.

## Changes Made

- Added `-e /.claude/settings.local.json` to the `clean` recipe, alongside the
  existing `-e /config.yaml`. Scoped to the exact file (not all of `.claude/`),
  so other untracked junk under `.claude/` is still cleaned.

`-x` is kept — it's required to remove the gitignored build outputs; the exclude
is the right tool for the specific local-config files that shouldn't be wiped.

## Security

None — build tooling only.

## Testing

Dry-run (`git clean -xdfn` with the excludes) confirms `config.yaml` and
`.claude/settings.local.json` are preserved while other untracked files (e.g. a
stray `.claude/*.tmp`, `.venv/`, `dist/`) are still removed.