### PR TITLE
fix(firewall): compare source IPs order-independently

### DIFF
--- a/src/cf_ips_to_hcloud_fw/firewall.py
+++ b/src/cf_ips_to_hcloud_fw/firewall.py
@@ -77,7 +77,10 @@ def update_source_ips(
     Returns:
         bool: True when the rule was modified.
     """
-    needs_update = rule.source_ips != cidrs
+    # Compare order-independently: Hetzner may return source_ips in a different
+    # order than we wrote them, and re-pushing an identically-membered list only
+    # causes needless API writes and firewall churn.
+    needs_update = set(rule.source_ips or []) != set(cidrs)
     if needs_update:
         rule.source_ips = cidrs
         logging.debug(

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -41,6 +41,20 @@ def test_update_source_ips(*, ips: list[str], cidrs: list[str], expected: bool) 
     assert fw.rules[0].source_ips == cidrs
 
 
+def test_update_source_ips_reordered_is_noop() -> None:
+    """Equal CIDR membership in a different order must not count as a change."""
+    existing = ["127.2/32", "127.1/32"]
+    rule = FirewallRule(FirewallRule.DIRECTION_IN, FirewallRule.PROTOCOL_TCP, existing)
+    fw = Firewall(rules=[rule])
+    needs_update = update_source_ips(
+        fw, rule, ["127.1/32", "127.2/32"], "", project_index=1
+    )
+    assert needs_update is False
+    assert fw.rules
+    # The rule is left untouched when only the order differs.
+    assert fw.rules[0].source_ips == existing
+
+
 @pytest.mark.parametrize(
     ("ipv4", "ipv6", "kind"),
     [


### PR DESCRIPTION
## Description

`update_source_ips` decided whether a rule needed updating with an
order-sensitive equality check (`rule.source_ips != cidrs`). Hetzner may
return a rule's `source_ips` in a different order than we wrote them, so a
rule with identical CIDR membership but different ordering was treated as
changed and re-pushed on every run. This switches the check to a
set-based comparison so a reordered-but-equal list is a no-op.

## Motivation

Avoids needless `firewalls.set_rules` API writes and firewall churn on
every sync when nothing has actually changed.

## Changes Made

- Compare source IPs as sets in `update_source_ips`
  (`set(rule.source_ips or []) != set(cidrs)`), with an explanatory comment.
- Add `test_update_source_ips_reordered_is_noop` covering the
  equal-but-reordered case (no update, rule left untouched).

## Security

None. Token handling and the computed CIDR set are unchanged; this only
affects whether an identical rule is re-pushed.

## Testing

`make check` — ruff + ty clean, 57 passed, 100% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firewall rule comparison to prevent unnecessary updates when IP addresses are provided in a different order but contain the same values.

* **Tests**
  * Added test to verify firewall rule updates handle reordered IP lists correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->