### PR TITLE
ci: pin uv in setup-uv and group uv updates together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -99,6 +99,14 @@
             ]
         },
         {
+            "description": "Keep uv together in one PR (the setup-uv action input and the Docker uv image).",
+            "groupName": "uv",
+            "matchPackageNames": [
+                "astral-sh/uv",
+                "ghcr.io/astral-sh/uv"
+            ]
+        },
+        {
             "automerge": true,
             "description": "Automerge digest-only refreshes and initial digest pins (actions + images).",
             "groupName": "digests",

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -65,6 +65,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          version: "0.11.21"
 
       - name: Sync dependencies
         run: uv sync --group dev --frozen

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -93,6 +93,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          version: "0.11.21"
 
       - name: Sync dependencies
         run: uv sync --group dev --frozen


### PR DESCRIPTION
## Description

`astral-sh/setup-uv` had no `version:` input, so CI installed *latest* uv — the
only floating dependency in an otherwise fully pinned setup (SHA-pinned actions,
digest-pinned images). This pins it for reproducible CI and lets Renovate keep it
current.

## Changes Made

- Pin `version: "0.11.21"` (matching the Dockerfile's uv) on the `setup-uv` step
  in `python-package.yaml` and `codeql.yaml`.
- Add a Renovate `packageRule` grouping `astral-sh/uv` (the setup-uv input,
  updated natively by the github-actions manager) and `ghcr.io/astral-sh/uv` (the
  Docker image) into a single **uv** PR — otherwise a uv release would arrive as
  two separate PRs. Digest-only refreshes still fall through to the automerged
  `digests` group.

## Security

None — CI tooling/config only. Removes a "latest" floating dependency, so it
slightly tightens reproducibility.

## Testing

`renovate-config-validator` passes; both workflows parse; the `version:` input is
present on both `setup-uv` steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to use package manager version 0.11.21
  * Configured dependency update grouping rules to batch related updates into single pull requests
  * Enhanced automation for build and code quality checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->