### PR TITLE
ci: run hooks via prek-action, let Renovate manage hook updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,8 @@
         "config:best-practices",
         ":gitSignOff",
         "schedule:earlyMondays",
-        "schedule:automergeDaily"
+        "schedule:automergeDaily",
+        ":enablePreCommit"
     ],
     "internalChecksFilter": "strict",
     "labels": [
@@ -54,6 +55,17 @@
             "matchManagers": [
                 "dockerfile",
                 "custom.regex"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch"
+            ]
+        },
+        {
+            "description": "Group pre-commit hook minor/patch into one PR; majors get their own PR.",
+            "groupName": "pre-commit",
+            "matchManagers": [
+                "pre-commit"
             ],
             "matchUpdateTypes": [
                 "minor",
@@ -99,10 +111,11 @@
             ]
         },
         {
-            "description": "Keep uv together in one PR (the setup-uv action input and the Docker uv image).",
+            "description": "Keep uv together in one PR (the setup-uv input, the Docker uv image, and the uv-pre-commit hook).",
             "groupName": "uv",
             "matchPackageNames": [
                 "astral-sh/uv",
+                "astral-sh/uv-pre-commit",
                 "ghcr.io/astral-sh/uv"
             ]
         },

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,44 @@
+name: pre-commit hooks
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prek:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          # prek installs hook environments from several registries (PyPI, npm,
+          # GitHub release assets); audit first, then tighten to block using the
+          # endpoints surfaced in the run summary.
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run prek
+        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4
+        env:
+          # ruff/ty run via `make lint`; uv-lock needs uv and is covered by
+          # Renovate lockfile maintenance plus the local hook.
+          SKIP: ruff-check,ruff-format,ty,uv-lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,3 @@
-ci:
-  autofix_prs: false
-  autoupdate_commit_msg: "chore(deps): update pre-commit repo revisions"
-  skip: [ruff-check, ruff-format, ty]  # need uv/venv; CI runs `make lint` (ruff + ty) instead
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
@@ -54,3 +49,8 @@ repos:
     rev: 996abf60411a8d954288ac9856aae7602b80cbda  # frozen: v0.22.1
     hooks:
       - id: markdownlint-cli2
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 9eba499c2181157fcf652119ad0927c299fbe324  # frozen: 43.220.0
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict]


### PR DESCRIPTION
## Description

Retires pre-commit.ci in favour of **Renovate** (hook-rev updates) + a **GitHub
Actions job** (running the hooks on PRs), consolidating dependency automation
into one tool — the same direction as the Dependabot→Renovate migration. Stays
on `.pre-commit-config.yaml` (no switch to `prek.toml`), which keeps it readable
by vanilla pre-commit, prek, and Renovate's native pre-commit manager.

## Changes Made

- **`renovate.json`**:
  - `:enablePreCommit` — Renovate now updates the repo-based hook `rev:` pins
    (pre-commit-hooks, uv-pre-commit, gitleaks, markdownlint-cli2), signed/grouped
    /scheduled like everything else. (Local `ruff`/`ty` hooks have no `rev:`, so
    they're untouched.)
  - New **`pre-commit`** group for those hooks.
  - Folded **`astral-sh/uv-pre-commit`** into the existing **`uv`** group — its
    version tracks uv (currently `0.11.21`, matching the Docker image and the
    setup-uv input), so all three uv refs now move in one PR.
- **`.pre-commit-config.yaml`**:
  - Dropped the `ci:` block (pre-commit.ci config).
  - Added `renovatebot/pre-commit-hooks` → `renovate-config-validator` with
    `--strict`, so config errors **and** migration warnings fail locally and in
    CI (would have caught the deprecated `docker` block we migrated by hand).
- **`.github/workflows/pre-commit.yaml`** (new): runs `j178/prek-action` on
  push/PR, skipping `ruff`/`ty` (covered by `make lint`) and `uv-lock` (needs uv;
  covered by Renovate lockfile maintenance + the local hook).

## Security

CI/config only. `harden-runner` uses `egress-policy: audit` for the new job
initially — prek pulls hook environments from PyPI/npm/GitHub, so a wrong
block-list would break it; tighten to `block` after reviewing the audit summary.
Secret scanning is unaffected (the `trufflehog` workflow still runs).

## Testing

- `renovate-config-validator --strict` passes (locally via the new hook).
- All workflows + `.pre-commit-config.yaml` parse.

## Before merging (manual)

- [ ] Uninstall the **pre-commit.ci** GitHub app so it stops running (its config
      block is removed here; Renovate + this workflow replace its two roles).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized dependency update automation with enhanced scheduling and intelligent grouping of package updates.
  * Added automated pre-commit hook enforcement for consistent code quality checks across all changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->