### PR TITLE
ci: pin prek uv source and tighten egress to block

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -26,10 +26,20 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           disable-sudo: true
-          # prek installs hook environments from several registries (PyPI, npm,
-          # GitHub release assets); audit first, then tighten to block using the
-          # endpoints surfaced in the run summary.
-          egress-policy: audit
+          egress-policy: block
+          # prek pulls hook environments: PyPI (python hooks + uv, pinned via
+          # PREK_UV_SOURCE below), npm + nodejs (markdownlint), Go proxy + sumdb
+          # storage (gitleaks), and GitHub.
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            nodejs.org:443
+            proxy.golang.org:443
+            pypi.org:443
+            raw.githubusercontent.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
 
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -41,4 +51,7 @@ jobs:
         env:
           # ruff/ty run via `make lint`; uv-lock needs uv and is covered by
           # Renovate lockfile maintenance plus the local hook.
+          # Pin prek's internal uv source to PyPI (already allowlisted) so it
+          # doesn't auto-probe mirrors — keeps egress deterministic under block.
+          PREK_UV_SOURCE: pypi
           SKIP: ruff-check,ruff-format,ty,uv-lock


### PR DESCRIPTION
## Description

Follow-up to #1276. The new prek workflow used `egress-policy: audit`; this pins
the egress to `block`. The blocker was understanding why the harden-runner audit
showed Aliyun/Tencent/Tsinghua mirror endpoints.

## Root cause

prek uses **uv** internally to build the Python hook environments (e.g.
`pre-commit-hooks`). With `PREK_UV_SOURCE` unset, prek *auto-selects* a uv source
and reached for those Chinese mirrors. Setting **`PREK_UV_SOURCE: pypi`** makes
it fetch uv from PyPI (already required for the python hooks), so egress is
deterministic and no mirror endpoints are needed.

## Changes Made

- `PREK_UV_SOURCE: pypi` on the prek step.
- `egress-policy: audit` → `block`, with an allowlist limited to what the hooks
  actually need: PyPI (`pypi.org`, `files.pythonhosted.org`), npm/node
  (`registry.npmjs.org`, `nodejs.org`), Go (`proxy.golang.org`,
  `storage.googleapis.com`), and GitHub (`github.com`,
  `raw.githubusercontent.com`, `release-assets.githubusercontent.com`).

## Security

Tightens the workflow: from observe-only to a blocked egress allowlist, and
removes reliance on third-party mirrors for the uv download.

## Testing

`pre-commit.yaml` parses. The block run on this PR will confirm the allowlist is
complete (if a hook needs an endpoint I missed, the prek job fails and we add it).