### PR TITLE
ci(ty): use github output format and fail on warnings

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -102,7 +102,7 @@ jobs:
         run: uv run --no-sync ruff check --output-format=github
 
       - name: Type check (ty)
-        run: uv run --no-sync ty check
+        run: uv run --no-sync ty check --output-format=github
 
       - name: Test
         run: uv run --no-sync pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/
     set -eux
     uv sync --link-mode copy --group dev --frozen
     uv run --no-sync ruff check --output-format=github
-    uv run --no-sync ty check
+    uv run --no-sync ty check --output-format=github
     uv run --no-sync pytest
     uv build
 EOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.15,<0.12"]
+requires = ["uv_build>=0.11.21,<0.12"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
@@ -148,3 +148,6 @@ ignore = [
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
+[tool.ty.terminal]
+error-on-warning = true


### PR DESCRIPTION
## Description

Configure the `ty` type checker to emit GitHub-style annotations in CI and the
Docker build, and make `ty` warnings fail the check. Also bump the `uv_build`
build-backend lower bound.

## Motivation

Using `--output-format=github` surfaces type-check findings as inline GitHub
annotations on PRs instead of plain log output. Enabling `error-on-warning`
prevents `ty` warnings from silently slipping through CI.

## Changes Made

- Pass `--output-format=github` to `ty check` in `.github/workflows/python-package.yaml`.
- Pass `--output-format=github` to `ty check` in the `Dockerfile` build step.
- Add `[tool.ty.terminal] error-on-warning = true` to `pyproject.toml`.
- Bump the `uv_build` build-backend lower bound from `0.11.15` to `0.11.21`.

## Security

None. No changes to token/secret handling or firewall rule computation.

## Testing

`make check` — ruff and ty clean, 57 passed, 100% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system dependency version.
  * Enhanced type checking configuration to fail on warnings.
  * Configured type checking output for improved GitHub Actions integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->