### PR TITLE
ci(docker): pin binfmt and buildkit images by digest

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,29 @@
             "matchStrings": [
                 "generator=(?<depName>docker/scout-sbom-indexer):(?<currentValue>[^@'\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
             ]
+        },
+        {
+            "customType": "regex",
+            "datasourceTemplate": "docker",
+            "description": "Pin tonistiigi/binfmt (setup-qemu-action image input) by version + digest.",
+            "managerFilePatterns": [
+                ".github/workflows/docker.yaml"
+            ],
+            "matchStrings": [
+                "image: (?<depName>tonistiigi/binfmt):(?<currentValue>qemu-v[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ],
+            "versioningTemplate": "regex:^qemu-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+        },
+        {
+            "customType": "regex",
+            "datasourceTemplate": "docker",
+            "description": "Pin moby/buildkit (setup-buildx-action driver image) digest; keep the curated buildx-stable-1 tag.",
+            "managerFilePatterns": [
+                ".github/workflows/docker.yaml"
+            ],
+            "matchStrings": [
+                "image=(?<depName>moby/buildkit):(?<currentValue>buildx-stable-1)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ]
         }
     ],
     "extends": [

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -99,9 +99,13 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        with:
+          image: tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
 
       - name: Login to DockerHub
         if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}


### PR DESCRIPTION
## Description

The multi-arch Docker build produces **signed, attested, SLSA-provenance**
images, but its two build-tooling images were floating: `setup-qemu-action`
pulled `tonistiigi/binfmt:latest` and `setup-buildx-action` used
`moby/buildkit:buildx-stable-1`. This pins both by digest so the signed build is
fully reproducible — closing the last "latest"/floating refs in that pipeline.

## Changes Made

- **setup-qemu-action**: `image: tonistiigi/binfmt:qemu-v10.2.3@sha256:…`
  (version + digest).
- **setup-buildx-action**: `driver-opts: image=moby/buildkit:buildx-stable-1@sha256:…`
  (keeps Docker's curated stable tag, digest-locked).
- **renovate.json**: two `customManager`s (datasource `docker`) so these
  in-action image refs stay current — binfmt version-bumps via a `qemu-v`
  versioning regex; buildkit gets digest refreshes. They land in the `docker`
  group (digest-only refreshes go to the automerged `digests` group).

## Security

Hardening only: removes reliance on floating `latest`/`buildx-stable-1` tooling
images in the provenance-generating build; everything in that build is now
digest-pinned.

## Testing

- `renovate-config-validator` passes; `docker.yaml` parses.
- Renovate dry-run confirms both customManagers extract the deps with the correct
  datasource/versioning (binfmt `qemu-v10.2.3`, buildkit `buildx-stable-1`).