### PR TITLE
ci: stop double-building PRs and cut Docker Hub pulls

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,7 +3,7 @@ name: CodeQL code scanning
 on:
   push:
     branches:
-      - "**"
+      - "main"
   pull_request:
     branches:
       - main

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "**"
+      - "main"
     tags:
       - "v*"
   pull_request:
@@ -97,16 +97,9 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && ',index' || '' }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-        with:
-          image: tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          driver-opts: image=moby/buildkit:buildx-stable-1@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
-
+      # Log in before pulling the QEMU/buildx tooling images so those Docker Hub
+      # pulls count against the authenticated limit, not the shared-runner
+      # anonymous pool.
       - name: Login to DockerHub
         if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -129,6 +122,20 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      # QEMU/binfmt only emulates non-host architectures; skip it (and its Docker
+      # Hub pull) unless we actually build multi-arch — PR/branch/bot builds are
+      # single-arch amd64.
+      - name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        with:
+          image: tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
 
       - name: Build and push
         id: build-and-push

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -3,7 +3,7 @@ name: pre-commit hooks
 on:
   push:
     branches:
-      - "**"
+      - "main"
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -3,7 +3,7 @@ name: Build, sign, and publish Python package
 on:
   push:
     branches:
-      - "**"
+      - "main"
     tags:
       - "v*"
   pull_request:


### PR DESCRIPTION
## Description

Two related CI-efficiency fixes. PR branches fired both `push` (`branches: "**"`)
and `pull_request`, so every PR built **twice**; and the Docker workflow hit
Docker Hub rate limits because its tooling images were pulled anonymously.

## Changes Made

**Stop double-building** — trim the `push` trigger from `"**"` to `main` (+ tags
where present) on `docker`, `python-package`, `codeql`, and `pre-commit`. PRs
still build via `pull_request`; `main`/tags still build. `trufflehog` keeps
`branches: "**"` so secret scanning runs on **every** push, not just PRs/main.

**Reduce Docker Hub pulls** (`docker.yaml`) — root cause: `binfmt` (Set up QEMU)
and `buildkit` (Set up Docker Buildx) were pulled *before* the `docker login`
steps, i.e. anonymously, against the shared GitHub-runner IP pool.
- Move the registry logins **before** the QEMU/buildx setup so those pulls are
  authenticated.
- Gate Set up QEMU to multi-arch runs only (PR/branch/bot builds are single-arch
  amd64 → no emulation, no `binfmt` pull).

## Security

CI only. `trufflehog` scanning coverage is unchanged (still every push). Docker
login guards are unchanged (just reordered).

## Notes

- Feature-branch pushes no longer trigger these builds — open a PR to run CI.
  `main`, tags, and PR builds are unaffected. (trufflehog still scans every push.)
- Base images already come from `ghcr.io` / `public.ecr.aws`, so the build's own
  pulls don't touch Docker Hub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow triggers to run push events only on the main branch instead of all branches
  * Optimized Docker workflow authentication and setup sequence for non-fork builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->