### PR TITLE
docs(changelog): record CI and dependency-tooling changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@
   secret mounts with a warning
 - Replaced `pyright` with `ty` for type checking in the lint pipeline and
   removed the `ms-python.vscode-pylance` VS Code extension recommendation
-- Start new development cycle
+- Migrated dependency automation from Dependabot to Renovate
+  (`config:best-practices`, grouped updates, automerge for low-risk bumps, and
+  digest pinning)
+- Pinned the remaining build-tooling images (binfmt, BuildKit, uv) by digest so
+  the signed multi-arch build is fully reproducible
+- Streamlined CI and contributor tooling: prek-based pre-commit runner,
+  concurrency limits and job timeouts, and fewer Docker Hub pulls / duplicate
+  PR builds
 
 ## [v1.2.1] – 2026-05-30
 


### PR DESCRIPTION
## Description

Records this cycle's notable infrastructure changes in the `Unreleased` section,
and drops the leftover `Start new development cycle` placeholder bullet now that
the section has real content.

## Changes Made

Added three consolidated entries (not a per-PR dump — matching the changelog's
existing style):
- Dependabot → Renovate migration.
- Digest-pinning the remaining build-tooling images (binfmt, BuildKit, uv).
- A single line for the rest of the CI/tooling streamlining (prek runner,
  concurrency + timeouts, fewer Docker Hub pulls / duplicate builds).

Internal-only changes (agent skills, CLAUDE.md, PR template, Makefile clean fix)
were intentionally left out as not user-facing.

## Testing

`markdownlint-cli2` passes on `CHANGELOG.md`.