### PR TITLE
feat(firewall): keep syncing when a firewall fails

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,12 +14,13 @@
 - `cloudflare.py` wraps the Cloudflare SDK, validates with `CloudflareCIDRs`, and
   fails via `log_error_and_exit`.
 - `firewall.py` edits Hetzner rules selected by `__CLOUDFLARE_IPS_*__` markers,
-  then calls `client.firewalls.set_rules`.
+  then calls `client.firewalls.set_rules`; per-firewall API errors are recorded
+  and the run continues, exiting non-zero at the end (see `ProjectOutcome`).
 - `config.py` loads YAML into `Project` models; empty/invalid configs exit early.
 - `models.py` defines Pydantic structures (`CloudflareCIDRs`, `Project`) used for
   validation and config.
-- `custom_logging.py` handles logging setup and exit routines
-  (`log_error_and_exit`).
+- `custom_logging.py` handles logging setup and the error helpers: `log_error`
+  (recoverable; logs and returns) and `log_error_and_exit` (logs then exits).
 - Tests in `tests/` mirror modules with mocked SDK clients for fast runs.
 
 ## Daily Flow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [v1.3.0] – Unreleased
 
+- Made firewall syncing resilient to per-firewall failures: a Hetzner API error
+  on one firewall (for example an expired token or a transient error) is now
+  logged and recorded instead of aborting the run, so the remaining firewalls
+  and projects are still processed. The CLI still exits with code 1 when any
+  firewall failed or was skipped, now reporting both groups in a single message
+  (`Some firewalls were not updated (failed: …; not found: …)`)
 - Upgraded Docker build provenance attestations to use the stable SLSA v1 schema
 - **Breaking:** Added POSIX config-permission checks that reject group/other
   writable config files while allowing common read-only Docker/Kubernetes

--- a/src/cf_ips_to_hcloud_fw/__main__.py
+++ b/src/cf_ips_to_hcloud_fw/__main__.py
@@ -35,13 +35,19 @@ def main() -> None:
     projects = read_config(args.config)
     cf_cidrs = get_cloudflare_cidrs()
     all_skipped: list[str] = []
+    all_failed: list[str] = []
     for idx, project in enumerate(projects, start=1):
-        skipped = update_project(project=project, cf_cidrs=cf_cidrs, project_index=idx)
-        all_skipped.extend(skipped)
+        outcome = update_project(project=project, cf_cidrs=cf_cidrs, project_index=idx)
+        all_skipped.extend(outcome.skipped)
+        all_failed.extend(outcome.failed)
 
-    if all_skipped:
-        msg = f"Some firewalls have been skipped: {', '.join(all_skipped)}"
-        log_error_and_exit(msg)
+    if all_failed or all_skipped:
+        parts: list[str] = []
+        if all_failed:
+            parts.append(f"failed: {', '.join(all_failed)}")
+        if all_skipped:
+            parts.append(f"not found: {', '.join(all_skipped)}")
+        log_error_and_exit(f"Some firewalls were not updated ({'; '.join(parts)})")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/cf_ips_to_hcloud_fw/custom_logging.py
+++ b/src/cf_ips_to_hcloud_fw/custom_logging.py
@@ -24,11 +24,23 @@ def setup_logging(args: argparse.Namespace) -> None:
     )
 
 
+def log_error(msg: str) -> None:
+    """Emit an error without terminating the process.
+
+    Use for recoverable failures that should be recorded but allow the run to
+    continue (for example, one firewall failing while others still sync).
+
+    Args:
+        msg: Pre-formatted error message to log.
+    """
+    logging.error(msg)
+
+
 def log_error_and_exit(msg: str) -> NoReturn:
     """Emit an error and terminate the process with exit code 1.
 
     Args:
         msg: Pre-formatted error message to log before exiting.
     """
-    logging.error(msg)
+    log_error(msg)
     sys.exit(1)

--- a/src/cf_ips_to_hcloud_fw/firewall.py
+++ b/src/cf_ips_to_hcloud_fw/firewall.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, NamedTuple
 from hcloud import APIException, Client
 from hcloud.firewalls.domain import Firewall, FirewallRule
 
-from cf_ips_to_hcloud_fw.custom_logging import log_error_and_exit
+from cf_ips_to_hcloud_fw.custom_logging import log_error
 
 if TYPE_CHECKING:  # pragma: no cover
     from cf_ips_to_hcloud_fw.models import CloudflareCIDRs, Project  # pragma: no cover
@@ -26,10 +26,27 @@ class IPVersionTargets(NamedTuple):
     ipv6: bool
 
 
+class ProjectOutcome(NamedTuple):
+    """Per-project result split into benign skips and hard failures.
+
+    Attributes:
+        skipped: Labels of firewalls that were not found (benign).
+        failed: Labels of firewalls whose sync errored against the API.
+    """
+
+    skipped: list[str]
+    failed: list[str]
+
+
 def update_project(
     *, project: Project, cf_cidrs: CloudflareCIDRs, project_index: int
-) -> list[str]:
+) -> ProjectOutcome:
     """Synchronize every firewall listed in a project with the latest CIDRs.
+
+    A failure on one firewall is logged and recorded, then the remaining
+    firewalls are still processed, so one bad token or transient API error
+    does not abort the whole run. The caller exits non-zero once every
+    firewall has been attempted.
 
     Args:
         project: Project definition that holds the API token and firewall names.
@@ -37,29 +54,34 @@ def update_project(
         project_index: 1-based index of the project being processed, used for logging.
 
     Returns:
-        list[str]: Labels of firewalls not found, prefixed with the project index.
+        ProjectOutcome: Labels of skipped and failed firewalls, project-prefixed.
     """
     client = Client(token=project.token.get_secret_value())
     skipped: list[str] = []
+    failed: list[str] = []
     for name in project.firewalls:
+        label = f"project {project_index}:{name!r}"
         try:
             fw = client.firewalls.get_by_name(name)
         except APIException as e:
-            log_error_and_exit(
+            log_error(
                 "hcloud/firewalls.get_by_name failed for "
                 f"{name!r} in project {project_index}: {e}"
             )
+            failed.append(label)
+            continue
         if fw:
             logging.info(
                 f"Inspecting hcloud firewall {name!r} in project {project_index}"
             )
-            update_firewall(client, fw, cf_cidrs, project_index=project_index)
+            if not update_firewall(client, fw, cf_cidrs, project_index=project_index):
+                failed.append(label)
         else:
             logging.debug(
                 f"hcloud firewall {name!r} not found in project {project_index}"
             )
-            skipped.append(f"project {project_index}:{name!r}")
-    return skipped
+            skipped.append(label)
+    return ProjectOutcome(skipped=skipped, failed=failed)
 
 
 def update_source_ips(
@@ -127,13 +149,16 @@ def update_firewall_rule(
     return update_source_ips(fw, rule, ip_cidrs, ip_type, project_index=project_index)
 
 
-def fw_set_rules(client: Client, fw: Firewall, project_index: int) -> None:
-    """Persist rule updates to Hetzner via the SDK, aborting on API errors.
+def fw_set_rules(client: Client, fw: Firewall, project_index: int) -> bool:
+    """Persist rule updates to Hetzner via the SDK.
 
     Args:
         client: Authenticated Hetzner Cloud client.
         fw: Firewall whose rules were modified earlier in the flow.
         project_index: 1-based index of the project being processed, used for logging.
+
+    Returns:
+        bool: True on success, False when the API call failed.
     """
     logging.info(
         f"Updating rules for hcloud firewall {fw.name!r} in project {project_index}"
@@ -142,15 +167,17 @@ def fw_set_rules(client: Client, fw: Firewall, project_index: int) -> None:
         rules = fw.rules or []
         client.firewalls.set_rules(fw, rules)
     except APIException as e:
-        log_error_and_exit(
+        log_error(
             f"hcloud/firewall.set_rules failed for {fw.name!r} in project "
             f"{project_index}: {e}"
         )
+        return False
+    return True
 
 
 def update_firewall(
     client: Client, fw: Firewall, cf_cidrs: CloudflareCIDRs, *, project_index: int
-) -> None:
+) -> bool:
     """Refresh all Cloudflare-tagged rules on a firewall and push changes.
 
     Args:
@@ -158,6 +185,9 @@ def update_firewall(
         fw: Firewall retrieved from the API.
         cf_cidrs: Cloudflare CIDR model downloaded at runtime.
         project_index: 1-based index of the project being processed, used for logging.
+
+    Returns:
+        bool: True on success (including no-op), False when pushing rules failed.
     """
     if fw.rules:
         needs_update = False
@@ -175,14 +205,13 @@ def update_firewall(
                     project_index=project_index,
                 )
         if needs_update:
-            fw_set_rules(client, fw, project_index=project_index)
-        else:
-            logging.info(
-                f"hcloud firewall {fw.name!r} in project {project_index} "
-                "already up-to-date"
-            )
+            return fw_set_rules(client, fw, project_index=project_index)
+        logging.info(
+            f"hcloud firewall {fw.name!r} in project {project_index} already up-to-date"
+        )
     else:
         logging.warning(
             f"hcloud firewall {fw.name!r} in project {project_index} "
             "has no rules - ignoring it"
         )
+    return True

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -271,21 +271,19 @@ def test_fw_set_rules(mock_client: MagicMock, *, rules: list[FirewallRule]) -> N
     """fw_set_rules forwards the current rule list to the SDK verbatim."""
     expected = rules or []
     fw = Firewall(name="fw-1", rules=rules)
-    fw_set_rules(mock_client, fw, 1)
+    assert fw_set_rules(mock_client, fw, 1) is True
     mock_client.firewalls.set_rules.assert_called_once_with(fw, expected)
 
 
 @patch("cf_ips_to_hcloud_fw.firewall.Client")
 @patch("logging.error")
 def test_fw_set_rules_fail(mock_logging: MagicMock, mock_client: MagicMock) -> None:
-    """fw_set_rules surfaces API exceptions via log_error_and_exit."""
+    """fw_set_rules logs API exceptions and reports failure without exiting."""
     fw = Firewall(name="fw-1", rules=[])
     mock_client.firewalls.set_rules.side_effect = APIException(
         "Test exception", "Message", "Details"
     )
-    with pytest.raises(SystemExit) as e:
-        fw_set_rules(mock_client, fw, 1)
-    assert e.value.code == 1
+    assert fw_set_rules(mock_client, fw, 1) is False
     mock_client.firewalls.set_rules.assert_called_once_with(fw, [])
     mock_logging.assert_called_once_with(
         "hcloud/firewall.set_rules failed for 'fw-1' in project 1: "
@@ -319,8 +317,8 @@ def test_update_project_found(
     cf_ips = CloudflareCIDRs(ipv4_cidrs=["127.1/32"], ipv6_cidrs=["::1/64"])
     mock_client.return_value.firewalls.get_by_name.return_value = fw
     project = Project(token=SecretStr("token-1"), firewalls=["fw-1"])
-    skipped = update_project(project=project, cf_cidrs=cf_ips, project_index=1)
-    assert skipped == []
+    outcome = update_project(project=project, cf_cidrs=cf_ips, project_index=1)
+    assert outcome == ([], [])
     mock_client.return_value.firewalls.get_by_name.assert_called_once_with("fw-1")
     mock_update_firewall.assert_called_once_with(
         mock_client.return_value, fw, cf_ips, project_index=1
@@ -336,12 +334,12 @@ def test_update_project_not_found(
     """Missing firewall names must log debug and continue processing."""
     mock_client.return_value.firewalls.get_by_name.return_value = None
     project = Project(token=SecretStr("token-1"), firewalls=["fw-1"])
-    skipped = update_project(
+    outcome = update_project(
         project=project,
         cf_cidrs=CloudflareCIDRs(ipv4_cidrs=["127.1/32"], ipv6_cidrs=["::1/64"]),
         project_index=1,
     )
-    assert skipped == ["project 1:'fw-1'"]
+    assert outcome == (["project 1:'fw-1'"], [])
     mock_client.return_value.firewalls.get_by_name.assert_called_once_with("fw-1")
     mock_update_firewall.assert_not_called()
     mock_logging.assert_called_once_with(
@@ -359,7 +357,7 @@ def test_update_project_not_found_with_special_name(
     mock_client.return_value.firewalls.get_by_name.return_value = None
     name = "fw-1's"
     project = Project(token=SecretStr("token-1"), firewalls=[name])
-    skipped = update_project(
+    outcome = update_project(
         project=project,
         cf_cidrs=CloudflareCIDRs(ipv4_cidrs=["127.1/32"], ipv6_cidrs=["::1/64"]),
         project_index=1,
@@ -367,7 +365,7 @@ def test_update_project_not_found_with_special_name(
 
     # Expect the repr() of the name to be used in the skipped entry and log
     expected = f"project 1:{name!r}"
-    assert skipped == [expected]
+    assert outcome == ([expected], [])
     mock_client.return_value.firewalls.get_by_name.assert_called_once_with(name)
     mock_update_firewall.assert_not_called()
     mock_logging.assert_called_once_with(
@@ -376,22 +374,54 @@ def test_update_project_not_found_with_special_name(
 
 
 @patch("cf_ips_to_hcloud_fw.firewall.Client")
+@patch("cf_ips_to_hcloud_fw.firewall.update_firewall", return_value=True)
 @patch("logging.error")
-def test_update_project_fail(mock_logging: MagicMock, mock_client: MagicMock) -> None:
-    """Exceptions from get_by_name bubble up via log_error_and_exit."""
-    mock_client.return_value.firewalls.get_by_name.side_effect = APIException(
-        "Test exception", "Message", "Details"
-    )
+def test_update_project_fail_continues(
+    mock_logging: MagicMock,
+    mock_update_firewall: MagicMock,
+    mock_client: MagicMock,
+) -> None:
+    """A get_by_name failure is recorded but the next firewall is still synced."""
+    fw2 = Firewall(2, "fw-2")
+    # fw-1 errors against the API; fw-2 must still be inspected afterwards.
+    mock_client.return_value.firewalls.get_by_name.side_effect = [
+        APIException("Test exception", "Message", "Details"),
+        fw2,
+    ]
     project = Project(token=SecretStr("token-1"), firewalls=["fw-1", "fw-2"])
-    with pytest.raises(SystemExit) as e:
-        update_project(
-            project=project,
-            cf_cidrs=CloudflareCIDRs(ipv4_cidrs=["127.1/32"], ipv6_cidrs=["::1/64"]),
-            project_index=1,
-        )
-    assert e.value.code == 1
-    mock_client.return_value.firewalls.get_by_name.assert_called_once_with("fw-1")
+    cf_ips = CloudflareCIDRs(ipv4_cidrs=["127.1/32"], ipv6_cidrs=["::1/64"])
+
+    outcome = update_project(project=project, cf_cidrs=cf_ips, project_index=1)
+
+    assert outcome == ([], ["project 1:'fw-1'"])
+    # Both firewalls were attempted despite fw-1 failing.
+    mock_client.return_value.firewalls.get_by_name.assert_has_calls([
+        call("fw-1"),
+        call("fw-2"),
+    ])
+    mock_update_firewall.assert_called_once_with(
+        mock_client.return_value, fw2, cf_ips, project_index=1
+    )
     mock_logging.assert_called_once_with(
         "hcloud/firewalls.get_by_name failed for 'fw-1' in project 1: "
         "Message (Test exception)"
+    )
+
+
+@patch("cf_ips_to_hcloud_fw.firewall.Client")
+@patch("cf_ips_to_hcloud_fw.firewall.update_firewall", return_value=False)
+def test_update_project_set_rules_fail_recorded(
+    mock_update_firewall: MagicMock, mock_client: MagicMock
+) -> None:
+    """A firewall whose rule push fails is recorded under failed, not skipped."""
+    fw = Firewall(1, "fw-1")
+    mock_client.return_value.firewalls.get_by_name.return_value = fw
+    project = Project(token=SecretStr("token-1"), firewalls=["fw-1"])
+    cf_ips = CloudflareCIDRs(ipv4_cidrs=["127.1/32"], ipv6_cidrs=["::1/64"])
+
+    outcome = update_project(project=project, cf_cidrs=cf_ips, project_index=1)
+
+    assert outcome == ([], ["project 1:'fw-1'"])
+    mock_update_firewall.assert_called_once_with(
+        mock_client.return_value, fw, cf_ips, project_index=1
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,6 +10,7 @@ from pydantic import SecretStr
 
 import cf_ips_to_hcloud_fw
 from cf_ips_to_hcloud_fw.__main__ import create_parser, main
+from cf_ips_to_hcloud_fw.firewall import ProjectOutcome
 from cf_ips_to_hcloud_fw.models import Project
 
 
@@ -64,7 +65,10 @@ def test_parser_version_no_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     ],
 )
 @patch("cf_ips_to_hcloud_fw.__main__.get_cloudflare_cidrs", MagicMock())
-@patch("cf_ips_to_hcloud_fw.__main__.update_project", return_value=[])
+@patch(
+    "cf_ips_to_hcloud_fw.__main__.update_project",
+    return_value=ProjectOutcome(skipped=[], failed=[]),
+)
 def test_main(mock_update_project: MagicMock, mock_projects: MagicMock) -> None:
     """main should iterate every parsed project and call update_project."""
     main()
@@ -85,7 +89,9 @@ def test_main(mock_update_project: MagicMock, mock_projects: MagicMock) -> None:
 @patch("cf_ips_to_hcloud_fw.__main__.get_cloudflare_cidrs", MagicMock())
 @patch(
     "cf_ips_to_hcloud_fw.__main__.update_project",
-    return_value=["project 1:fw-2", "project 1:fw-3"],
+    return_value=ProjectOutcome(
+        skipped=["project 1:fw-2", "project 1:fw-3"], failed=[]
+    ),
 )
 @patch("logging.error")
 def test_main_with_skipped_firewalls(
@@ -97,7 +103,7 @@ def test_main_with_skipped_firewalls(
     assert e.value.code == 1
     assert mock_update_project.call_count == len(mock_projects.return_value)
     mock_logging.assert_called_once_with(
-        "Some firewalls have been skipped: project 1:fw-2, project 1:fw-3"
+        "Some firewalls were not updated (not found: project 1:fw-2, project 1:fw-3)"
     )
 
 
@@ -112,7 +118,10 @@ def test_main_with_skipped_firewalls(
 @patch("cf_ips_to_hcloud_fw.__main__.get_cloudflare_cidrs", MagicMock())
 @patch(
     "cf_ips_to_hcloud_fw.__main__.update_project",
-    side_effect=[["project 1:fw-1"], ["project 2:fw-3", "project 2:fw-4"]],
+    side_effect=[
+        ProjectOutcome(skipped=["project 1:fw-1"], failed=[]),
+        ProjectOutcome(skipped=["project 2:fw-3", "project 2:fw-4"], failed=[]),
+    ],
 )
 @patch("logging.error")
 def test_main_with_skipped_firewalls_multiple_projects(
@@ -124,6 +133,62 @@ def test_main_with_skipped_firewalls_multiple_projects(
     assert e.value.code == 1
     assert mock_update_project.call_count == len(mock_projects.return_value)
     mock_logging.assert_called_once_with(
-        "Some firewalls have been skipped: "
-        "project 1:fw-1, project 2:fw-3, project 2:fw-4"
+        "Some firewalls were not updated (not found: "
+        "project 1:fw-1, project 2:fw-3, project 2:fw-4)"
+    )
+
+
+@patch("cf_ips_to_hcloud_fw.__main__.create_parser", MagicMock())
+@patch(
+    "cf_ips_to_hcloud_fw.__main__.read_config",
+    return_value=[
+        Project(token=SecretStr("token-1"), firewalls=["fw-1"]),
+        Project(token=SecretStr("token-2"), firewalls=["fw-2"]),
+    ],
+)
+@patch("cf_ips_to_hcloud_fw.__main__.get_cloudflare_cidrs", MagicMock())
+@patch(
+    "cf_ips_to_hcloud_fw.__main__.update_project",
+    side_effect=[
+        ProjectOutcome(skipped=[], failed=["project 1:fw-1"]),
+        ProjectOutcome(skipped=[], failed=[]),
+    ],
+)
+@patch("logging.error")
+def test_main_failed_project_does_not_abort_remaining(
+    mock_logging: MagicMock, mock_update_project: MagicMock, mock_projects: MagicMock
+) -> None:
+    """A failure in project 1 must not prevent project 2 from being processed."""
+    with pytest.raises(SystemExit) as e:
+        main()
+    assert e.value.code == 1
+    # Both projects were attempted even though the first one failed.
+    assert mock_update_project.call_count == len(mock_projects.return_value)
+    mock_logging.assert_called_once_with(
+        "Some firewalls were not updated (failed: project 1:fw-1)"
+    )
+
+
+@patch("cf_ips_to_hcloud_fw.__main__.create_parser", MagicMock())
+@patch(
+    "cf_ips_to_hcloud_fw.__main__.read_config",
+    return_value=[Project(token=SecretStr("token-1"), firewalls=["fw-1", "fw-2"])],
+)
+@patch("cf_ips_to_hcloud_fw.__main__.get_cloudflare_cidrs", MagicMock())
+@patch(
+    "cf_ips_to_hcloud_fw.__main__.update_project",
+    return_value=ProjectOutcome(skipped=["project 1:fw-2"], failed=["project 1:fw-1"]),
+)
+@patch("logging.error")
+def test_main_reports_failed_and_skipped(
+    mock_logging: MagicMock, mock_update_project: MagicMock, mock_projects: MagicMock
+) -> None:
+    """Both failed and not-found firewalls are reported, failures listed first."""
+    with pytest.raises(SystemExit) as e:
+        main()
+    assert e.value.code == 1
+    assert mock_update_project.call_count == len(mock_projects.return_value)
+    mock_logging.assert_called_once_with(
+        "Some firewalls were not updated "
+        "(failed: project 1:fw-1; not found: project 1:fw-2)"
     )


### PR DESCRIPTION
## Description

A Hetzner API error on a single firewall used to call `log_error_and_exit`
and abort the entire run, abandoning every remaining firewall — and every
later project. This makes syncing resilient: a per-firewall failure (an
expired token, a transient API error) is logged and recorded, then the
remaining firewalls and projects are still processed. The CLI still exits
with code 1 when anything failed or was skipped.

## Motivation

For a cron-driven tool that syncs several projects/firewalls, one bad token
or a momentary API hiccup should not silently stop everything else from
being updated.

## Changes Made

- `update_project` returns a `ProjectOutcome(skipped, failed)` NamedTuple and
  catches `APIException` per firewall, continuing instead of exiting.
- `fw_set_rules` and `update_firewall` return success booleans instead of
  exiting on error.
- `main` aggregates failed and skipped firewalls across all projects and
  reports them in a single message:
  `Some firewalls were not updated (failed: ...; not found: ...)`.
- Added `log_error` as the recoverable (non-exiting) sibling of
  `log_error_and_exit`, which now delegates to it.
- Updated the CHANGELOG and the `firewall`/`custom_logging` entries in the
  contributor onboarding doc.

## Security

None. Token handling and the computed CIDR set are unchanged; this only
affects error handling and control flow when an API call fails.

## Testing

`make check` — ruff + ty clean, 60 passed, 100% coverage. New tests cover a
firewall failure being survived within a project, a failed firewall recorded
under `failed`, cross-project continuation after a failure, and the combined
failed + not-found exit message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Firewall syncing is now resilient to per-firewall API failures—errors on individual firewalls are logged and recorded while remaining firewalls continue processing.
  * Improved error reporting with combined messages displaying both failed and not-found firewalls.

* **Documentation**
  * Updated documentation to reflect firewall error handling and logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->