### PR TITLE
feat(config): add env-var config and auto-detect default config.yaml

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,9 @@
 - `firewall.py` edits Hetzner rules selected by `__CLOUDFLARE_IPS_*__` markers,
   then calls `client.firewalls.set_rules`; per-firewall API errors are recorded
   and the run continues, exiting non-zero at the end (see `ProjectOutcome`).
-- `config.py` loads YAML into `Project` models; empty/invalid configs exit early.
+- `config.py` resolves `Project` models via `load_projects`: explicit `-c` file,
+  else a default `config.yaml`, else `HCLOUD_TOKEN` + `HCLOUD_FIREWALLS` env vars
+  (`read_config` / `read_config_from_env`); empty/invalid configs exit early.
 - `models.py` defines Pydantic structures (`CloudflareCIDRs`, `Project`) used for
   validation and config.
 - `custom_logging.py` handles logging setup and the error helpers: `log_error`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [v1.3.0] – Unreleased
 
+- Added an environment-variable configuration mode for the common single-project
+  case: when `-c/--config` is omitted, the tool uses a `config.yaml` in the
+  working directory if present, otherwise builds one project from `HCLOUD_TOKEN`
+  and a comma-separated `HCLOUD_FIREWALLS` list. Docker and Kubernetes users can
+  now pass the token as a native secret without mounting a config file, and the
+  container image's default command works for both file-mounted and env-var
+  setups. Passing `-c` keeps that file as the sole source
 - Made firewall syncing resilient to per-firewall failures: a Hetzner API error
   on one firewall (for example an expired token or a transient error) is now
   logged and recorded instead of aborting the run, so the remaining firewalls

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,6 @@ RUN --mount=type=bind,from=uv-tools-alpine,source=/usr/local/bin/uv,target=/usr/
 
 USER 65534
 
-CMD [".venv/bin/cf-ips-to-hcloud-fw", "-c", "config.yaml"]
+# No -c: the tool auto-detects ./config.yaml (mount it at /usr/src/app/config.yaml)
+# and otherwise falls back to the HCLOUD_TOKEN / HCLOUD_FIREWALLS env vars.
+CMD [".venv/bin/cf-ips-to-hcloud-fw"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ rules up-to-date with the current Cloudflare IP ranges.
 - [Configuration](#configuration)
   - [Preparing the Hetzner Cloud Firewall](#preparing-the-hetzner-cloud-firewall)
   - [Configuring the Application](#configuring-the-application)
+  - [Using Environment Variables (Single Project)](#using-environment-variables-single-project)
 - [Usage](#usage)
   - [Command-line Options](#command-line-options)
 - [Verifying SLSA Attestations](#verifying-slsa-attestations)
@@ -144,6 +145,19 @@ docker run --rm \
 
 (Add `--pull=always` if you use a rolling image tag.)
 
+Alternatively, for a single project you can skip the mounted file and pass the
+token and firewalls as environment variables (see [Using Environment
+Variables](#using-environment-variables-single-project)). The image auto-detects
+a mounted `config.yaml` and otherwise falls back to these variables, so no
+command override is needed:
+
+```shell
+docker run --rm \
+  -e HCLOUD_TOKEN=your-api-token \
+  -e HCLOUD_FIREWALLS=firewall-1,firewall-2 \
+  jkreileder/cf-ips-to-hcloud-fw:1.2.1
+```
+
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 `linux/arm64` architectures.  The Docker images support the following tags:
 
@@ -220,6 +234,25 @@ spec:
           restartPolicy: OnFailure
 ```
 
+For a single project, you can drop the Secret, volume, and `volumeMounts` above
+and instead supply the token and firewalls via `env` (for example from a
+Secret). No command override is needed — with no `config.yaml` mounted, the tool
+falls back to these variables:
+
+```yaml
+containers:
+  - name: cf-ips-to-hcloud-fw
+    image: jkreileder/cf-ips-to-hcloud-fw:1.2.1
+    env:
+      - name: HCLOUD_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cf-ips-to-hcloud-fw-token
+            key: token
+      - name: HCLOUD_FIREWALLS
+        value: firewall-1,firewall-2
+```
+
 ## Configuration
 
 ### Preparing the Hetzner Cloud Firewall
@@ -263,6 +296,32 @@ file:
 For local files, prefer owner-only access (for example `chmod 600 config.yaml`)
 where practical.
 
+### Using Environment Variables (Single Project)
+
+For the common single-project case — typical in Docker and Kubernetes — you can
+skip the config file entirely and provide the token and firewalls through
+environment variables instead. When `-c/--config` is omitted, the tool builds a
+single project from:
+
+- `HCLOUD_TOKEN`: API token with read-write permissions for the Hetzner Cloud
+  project.
+- `HCLOUD_FIREWALLS`: comma-separated list of firewall names to update (for
+  example `fw-1,fw-2`).
+
+```shell
+export HCLOUD_TOKEN=your-api-token
+export HCLOUD_FIREWALLS=firewall-1,firewall-2
+cf-ips-to-hcloud-fw
+```
+
+This keeps the token out of any on-disk file and lets you pass it as a native
+Docker/Kubernetes secret.
+
+Configuration is resolved in this order: an explicit `-c/--config` file is the
+sole source; otherwise a `config.yaml` in the working directory is used if
+present; otherwise the environment variables above are used. A present config
+file therefore takes precedence over the environment variables.
+
 ## Usage
 
 Run the tool with your configuration file:
@@ -273,7 +332,10 @@ cf-ips-to-hcloud-fw -c config.yaml
 
 ### Command-line Options
 
-- `-c, --config FILE`: Path to the configuration file (required)
+- `-c, --config FILE`: Path to the configuration file. If omitted, a
+  `config.yaml` in the working directory is used when present, otherwise a single
+  project is built from the `HCLOUD_TOKEN` and `HCLOUD_FIREWALLS` environment
+  variables (see [Using Environment Variables](#using-environment-variables-single-project))
 - `-d, --debug`: Enable debug logging for troubleshooting
 - `-v, --version`: Display the installed version
 

--- a/src/cf_ips_to_hcloud_fw/__main__.py
+++ b/src/cf_ips_to_hcloud_fw/__main__.py
@@ -4,7 +4,7 @@ import argparse
 
 from cf_ips_to_hcloud_fw import __version__
 from cf_ips_to_hcloud_fw.cloudflare import get_cloudflare_cidrs
-from cf_ips_to_hcloud_fw.config import read_config
+from cf_ips_to_hcloud_fw.config import load_projects
 from cf_ips_to_hcloud_fw.custom_logging import log_error_and_exit, setup_logging
 from cf_ips_to_hcloud_fw.firewall import update_project
 
@@ -19,7 +19,14 @@ def create_parser() -> argparse.ArgumentParser:
         description="Update Hetzner Cloud firewall rules with Cloudflare IP ranges"
     )
     parser.add_argument(
-        "-c", "--config", help="config file", metavar="CONFIGFILE", required=True
+        "-c",
+        "--config",
+        help=(
+            "config file; if omitted, a 'config.yaml' in the working directory "
+            "is used when present, otherwise a single project is built from the "
+            "HCLOUD_TOKEN and HCLOUD_FIREWALLS environment variables"
+        ),
+        metavar="CONFIGFILE",
     )
     parser.add_argument("-v", "--version", action="version", version=__version__)
     parser.add_argument("-d", "--debug", action="store_true")
@@ -32,7 +39,7 @@ def main() -> None:
     args = parser.parse_args()
     setup_logging(args)
 
-    projects = read_config(args.config)
+    projects = load_projects(args.config)
     cf_cidrs = get_cloudflare_cidrs()
     all_skipped: list[str] = []
     all_failed: list[str] = []

--- a/src/cf_ips_to_hcloud_fw/config.py
+++ b/src/cf_ips_to_hcloud_fw/config.py
@@ -6,10 +6,14 @@ import stat
 import sys
 
 import yaml
-from pydantic import TypeAdapter, ValidationError
+from pydantic import SecretStr, TypeAdapter, ValidationError
 
 from cf_ips_to_hcloud_fw.custom_logging import log_error_and_exit
 from cf_ips_to_hcloud_fw.models import Project
+
+ENV_TOKEN = "HCLOUD_TOKEN"  # noqa: S105 # env var name, not a secret value
+ENV_FIREWALLS = "HCLOUD_FIREWALLS"
+DEFAULT_CONFIG_FILE = "config.yaml"
 
 
 def _validate_config_permissions(config_file: str) -> None:
@@ -79,3 +83,58 @@ def read_config(config_file: str) -> list[Project]:
         sys.exit(0)
 
     return projects
+
+
+def read_config_from_env() -> list[Project]:
+    """Build a single-project config from environment variables.
+
+    Used when no config file is given. Reads the API token from ``HCLOUD_TOKEN``
+    and a comma-separated firewall list from ``HCLOUD_FIREWALLS``, so the common
+    single-project Docker/Kubernetes case needs no config file on disk.
+
+    Returns:
+        list[Project]: A single-element list with the env-derived project.
+    """
+    token = os.environ.get(ENV_TOKEN)
+    if not token:
+        log_error_and_exit(
+            f"No configuration found and {ENV_TOKEN} is not set; provide -c "
+            f"CONFIGFILE or a {DEFAULT_CONFIG_FILE!r} file, or set {ENV_TOKEN} "
+            f"and {ENV_FIREWALLS}."
+        )
+
+    firewalls = [
+        fw.strip() for fw in os.environ.get(ENV_FIREWALLS, "").split(",") if fw.strip()
+    ]
+    if not firewalls:
+        log_error_and_exit(
+            f"{ENV_FIREWALLS} is empty; set it to a comma-separated list of "
+            "firewall names (for example 'fw-1,fw-2')."
+        )
+
+    return [Project(token=SecretStr(token), firewalls=firewalls)]
+
+
+def load_projects(config_file: str | None) -> list[Project]:
+    """Resolve the project list from the CLI flag, a default file, or env vars.
+
+    Precedence:
+
+    1. An explicit ``config_file`` (``-c``) is the sole source.
+    2. Otherwise a ``config.yaml`` in the working directory, if present. This
+       keeps mounted-file Docker/Kubernetes setups working with the image's
+       default command and avoids an ambient ``HCLOUD_TOKEN`` (a shared variable
+       name) silently overriding a real config file.
+    3. Otherwise the ``HCLOUD_TOKEN``/``HCLOUD_FIREWALLS`` environment variables.
+
+    Args:
+        config_file: Explicit config path from ``-c``, or None when not given.
+
+    Returns:
+        list[Project]: Ordered list of validated project definitions.
+    """
+    if config_file is not None:
+        return read_config(config_file)
+    if os.path.exists(DEFAULT_CONFIG_FILE):
+        return read_config(DEFAULT_CONFIG_FILE)
+    return read_config_from_env()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 from pydantic import SecretStr
 
-from cf_ips_to_hcloud_fw.config import read_config
+from cf_ips_to_hcloud_fw.config import (
+    load_projects,
+    read_config,
+    read_config_from_env,
+)
 from cf_ips_to_hcloud_fw.models import Project
 
 
@@ -345,3 +349,142 @@ def test_read_config_validation_error_redacts_secret_value(
     error_msg = mock_logging.call_args[0][0]
     assert "Config file 'config.yaml' is broken:" in error_msg
     assert "SUPER_SECRET_TOKEN_VALUE" not in error_msg
+
+
+@patch.dict(
+    "os.environ",
+    {"HCLOUD_TOKEN": "env-token", "HCLOUD_FIREWALLS": "fw-1,fw-2"},
+    clear=True,
+)
+def test_read_config_from_env() -> None:
+    """A token and comma-separated firewall list build a single project."""
+    projects = read_config_from_env()
+    assert projects == [
+        Project(token=SecretStr("env-token"), firewalls=["fw-1", "fw-2"])
+    ]
+
+
+@patch.dict(
+    "os.environ",
+    {"HCLOUD_TOKEN": "env-token", "HCLOUD_FIREWALLS": " fw-1 , ,fw-2 ,"},
+    clear=True,
+)
+def test_read_config_from_env_trims_and_filters_firewalls() -> None:
+    """Whitespace is trimmed and empty entries dropped from the firewall list."""
+    projects = read_config_from_env()
+    assert projects == [
+        Project(token=SecretStr("env-token"), firewalls=["fw-1", "fw-2"])
+    ]
+
+
+@patch.dict("os.environ", {"HCLOUD_FIREWALLS": "fw-1"}, clear=True)
+@patch("logging.error")
+def test_read_config_from_env_missing_token(mock_logging: MagicMock) -> None:
+    """A missing HCLOUD_TOKEN exits with a helpful error."""
+    with pytest.raises(SystemExit) as e:
+        read_config_from_env()
+    assert e.value.code == 1
+    mock_logging.assert_called_once()
+    error_msg = mock_logging.call_args[0][0]
+    assert "HCLOUD_TOKEN is not set" in error_msg
+
+
+@patch.dict("os.environ", {"HCLOUD_TOKEN": "env-token"}, clear=True)
+@patch("logging.error")
+def test_read_config_from_env_missing_firewalls(mock_logging: MagicMock) -> None:
+    """A token without any firewalls exits with a helpful error."""
+    with pytest.raises(SystemExit) as e:
+        read_config_from_env()
+    assert e.value.code == 1
+    mock_logging.assert_called_once()
+    error_msg = mock_logging.call_args[0][0]
+    assert "HCLOUD_FIREWALLS is empty" in error_msg
+
+
+@patch.dict(
+    "os.environ",
+    {"HCLOUD_TOKEN": "SUPER_SECRET_TOKEN_VALUE", "HCLOUD_FIREWALLS": " , "},
+    clear=True,
+)
+@patch("logging.error")
+def test_read_config_from_env_blank_firewalls_redacts_token(
+    mock_logging: MagicMock,
+) -> None:
+    """The firewalls error must not leak the token value."""
+    with pytest.raises(SystemExit) as e:
+        read_config_from_env()
+    assert e.value.code == 1
+    mock_logging.assert_called_once()
+    assert "SUPER_SECRET_TOKEN_VALUE" not in mock_logging.call_args[0][0]
+
+
+@patch("cf_ips_to_hcloud_fw.config.read_config_from_env")
+@patch("cf_ips_to_hcloud_fw.config.os.path.exists")
+@patch("cf_ips_to_hcloud_fw.config.read_config")
+def test_load_projects_explicit_config_wins(
+    mock_read_config: MagicMock,
+    mock_exists: MagicMock,
+    mock_read_env: MagicMock,
+) -> None:
+    """An explicit -c path is the sole source; no default-file or env lookup."""
+    mock_read_config.return_value = [Project(token=SecretStr("t"), firewalls=["fw"])]
+    result = load_projects("custom.yaml")
+    assert result is mock_read_config.return_value
+    mock_read_config.assert_called_once_with("custom.yaml")
+    mock_exists.assert_not_called()
+    mock_read_env.assert_not_called()
+
+
+@patch("cf_ips_to_hcloud_fw.config.read_config_from_env")
+@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
+@patch("cf_ips_to_hcloud_fw.config.read_config")
+def test_load_projects_default_file_used(
+    mock_read_config: MagicMock,
+    mock_exists: MagicMock,
+    mock_read_env: MagicMock,
+) -> None:
+    """With no -c, a present config.yaml is used before the env fallback."""
+    mock_read_config.return_value = [Project(token=SecretStr("t"), firewalls=["fw"])]
+    result = load_projects(None)
+    assert result is mock_read_config.return_value
+    mock_exists.assert_called_once_with("config.yaml")
+    mock_read_config.assert_called_once_with("config.yaml")
+    mock_read_env.assert_not_called()
+
+
+@patch.dict(
+    "os.environ",
+    {"HCLOUD_TOKEN": "env-token", "HCLOUD_FIREWALLS": "fw-1"},
+    clear=True,
+)
+@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
+@patch("cf_ips_to_hcloud_fw.config.read_config_from_env")
+@patch("cf_ips_to_hcloud_fw.config.read_config")
+def test_load_projects_file_beats_env(
+    mock_read_config: MagicMock,
+    mock_read_env: MagicMock,
+    mock_exists: MagicMock,
+) -> None:
+    """A present config.yaml takes precedence over set environment variables."""
+    mock_read_config.return_value = [Project(token=SecretStr("t"), firewalls=["fw"])]
+    load_projects(None)
+    mock_exists.assert_called_once_with("config.yaml")
+    mock_read_config.assert_called_once_with("config.yaml")
+    mock_read_env.assert_not_called()
+
+
+@patch("cf_ips_to_hcloud_fw.config.read_config")
+@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=False)
+@patch("cf_ips_to_hcloud_fw.config.read_config_from_env")
+def test_load_projects_env_fallback(
+    mock_read_env: MagicMock,
+    mock_exists: MagicMock,
+    mock_read_config: MagicMock,
+) -> None:
+    """With no -c and no config.yaml, the env-var path is used."""
+    mock_read_env.return_value = [Project(token=SecretStr("t"), firewalls=["fw"])]
+    result = load_projects(None)
+    assert result is mock_read_env.return_value
+    mock_exists.assert_called_once_with("config.yaml")
+    mock_read_config.assert_not_called()
+    mock_read_env.assert_called_once_with()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,6 +29,10 @@ def test_create_parser() -> None:
     args = parser.parse_args(["-c", "config2.yaml"])
     assert args.config == "config2.yaml"
     assert args.debug is False
+    # -c is optional: without it the env-var fallback kicks in downstream.
+    args = parser.parse_args([])
+    assert args.config is None
+    assert args.debug is False
 
 
 def test_parser_version(capfd: pytest.CaptureFixture[str]) -> None:
@@ -58,7 +62,7 @@ def test_parser_version_no_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @patch("cf_ips_to_hcloud_fw.__main__.create_parser", MagicMock())
 @patch(
-    "cf_ips_to_hcloud_fw.__main__.read_config",
+    "cf_ips_to_hcloud_fw.__main__.load_projects",
     return_value=[
         Project(token=SecretStr("token-1"), firewalls=["fw-1", "fw-2"]),
         Project(token=SecretStr("token-2"), firewalls=["fw-1", "fw-2"]),
@@ -81,7 +85,7 @@ def test_main(mock_update_project: MagicMock, mock_projects: MagicMock) -> None:
 
 @patch("cf_ips_to_hcloud_fw.__main__.create_parser", MagicMock())
 @patch(
-    "cf_ips_to_hcloud_fw.__main__.read_config",
+    "cf_ips_to_hcloud_fw.__main__.load_projects",
     return_value=[
         Project(token=SecretStr("token-1"), firewalls=["fw-1", "fw-2"]),
     ],
@@ -109,7 +113,7 @@ def test_main_with_skipped_firewalls(
 
 @patch("cf_ips_to_hcloud_fw.__main__.create_parser", MagicMock())
 @patch(
-    "cf_ips_to_hcloud_fw.__main__.read_config",
+    "cf_ips_to_hcloud_fw.__main__.load_projects",
     return_value=[
         Project(token=SecretStr("token-1"), firewalls=["fw-2"]),
         Project(token=SecretStr("token-3"), firewalls=["fw-4"]),
@@ -140,7 +144,7 @@ def test_main_with_skipped_firewalls_multiple_projects(
 
 @patch("cf_ips_to_hcloud_fw.__main__.create_parser", MagicMock())
 @patch(
-    "cf_ips_to_hcloud_fw.__main__.read_config",
+    "cf_ips_to_hcloud_fw.__main__.load_projects",
     return_value=[
         Project(token=SecretStr("token-1"), firewalls=["fw-1"]),
         Project(token=SecretStr("token-2"), firewalls=["fw-2"]),
@@ -171,7 +175,7 @@ def test_main_failed_project_does_not_abort_remaining(
 
 @patch("cf_ips_to_hcloud_fw.__main__.create_parser", MagicMock())
 @patch(
-    "cf_ips_to_hcloud_fw.__main__.read_config",
+    "cf_ips_to_hcloud_fw.__main__.load_projects",
     return_value=[Project(token=SecretStr("token-1"), firewalls=["fw-1", "fw-2"])],
 )
 @patch("cf_ips_to_hcloud_fw.__main__.get_cloudflare_cidrs", MagicMock())


### PR DESCRIPTION
## Description

For the common single-project case — typical in Docker and Kubernetes —
mounting a YAML file just to pass one token is awkward and puts the secret on
disk. This makes `-c/--config` optional and resolves the project list through a
new `load_projects` helper with clear precedence:

1. an explicit `-c` file is the sole source;
2. otherwise a `config.yaml` in the working directory, if present;
3. otherwise the `HCLOUD_TOKEN` and comma-separated `HCLOUD_FIREWALLS`
   environment variables.

A present config file beats the environment variables, so an ambient
`HCLOUD_TOKEN` (a widely shared variable name) cannot silently override a mounted
config file. The container image's default command drops the hardcoded
`-c config.yaml` and relies on this resolution instead, so the same image works
unchanged for both file-mounted and env-var setups — no command override needed.

## Motivation

Let Docker/Kubernetes users pass the token as a native secret without mounting a
config file, while keeping every existing file-based invocation working exactly
as before.

## Changes Made

- Added `read_config_from_env` (`HCLOUD_TOKEN` + comma-separated
  `HCLOUD_FIREWALLS`, trimmed/empty-filtered) and `load_projects`, which applies
  the precedence above. Both funnel through the existing `Project` model so
  validation and errors stay consistent.
- Made `-c/--config` optional; `main` now calls `load_projects(args.config)`.
- Dropped the hardcoded `-c config.yaml` from the image `CMD` so the default
  command serves both file-mounted and env-var setups.
- Updated `--help`, the README (Configuration, Command-line Options, Docker and
  Kubernetes), the CHANGELOG, and the contributor onboarding doc.

## Security

The token can now be supplied via an environment variable instead of an on-disk
file, sidestepping the config-file-on-disk concern for the single-project case.
File-wins precedence prevents an ambient `HCLOUD_TOKEN` from overriding a real
config file. Not marked breaking: existing invocations and exit codes are
unchanged.

## Testing

`make check` — ruff + ty clean, 69 passed, 100% coverage. New tests cover the
env-var parsing (trimming, missing token, empty firewalls, token redaction) and
the `load_projects` precedence (explicit `-c`, default file, file-beats-env,
env fallback). Manually verified the resolution order end-to-end and that
`--help` reflects it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring projects via environment variables (`HCLOUD_TOKEN`, `HCLOUD_FIREWALLS`) when no config file is provided, enabling simplified single-project setup for containerized deployments.

* **Documentation**
  * Updated guides and help text to document environment variable configuration and configuration resolution precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->