### PR TITLE
refactor(cloudflare): drop dummy api_key, omit auth for public ips.list

### DIFF
--- a/src/cf_ips_to_hcloud_fw/cloudflare.py
+++ b/src/cf_ips_to_hcloud_fw/cloudflare.py
@@ -4,10 +4,21 @@ import logging
 
 import cloudflare
 import cloudflare.types.ips
+from cloudflare import Omit
 from pydantic import TypeAdapter, ValidationError
 
 from cf_ips_to_hcloud_fw.custom_logging import log_error_and_exit
 from cf_ips_to_hcloud_fw.models import CloudflareCIDRs, CloudflareIPNetworks
+
+# `ips.list` is a public endpoint that needs no credentials. The SDK otherwise
+# refuses to send a request without an auth method, so explicitly omit the auth
+# headers — this sends no credential at all, instead of a placeholder key.
+_NO_AUTH_HEADERS = {
+    "Authorization": Omit(),
+    "X-Auth-Email": Omit(),
+    "X-Auth-Key": Omit(),
+    "X-Auth-User-Service-Key": Omit(),
+}
 
 
 def cf_ips_list() -> cloudflare.types.ips.IPListResponse | None:
@@ -17,9 +28,9 @@ def cf_ips_list() -> cloudflare.types.ips.IPListResponse | None:
         cloudflare.types.ips.IPListResponse | None: Raw API response, or None
         when the SDK returns no payload.
     """
-    cf = cloudflare.Cloudflare(api_key="dummy")  # required to pass credential check
+    cf = cloudflare.Cloudflare()
     try:
-        return cf.ips.list()
+        return cf.ips.list(extra_headers=_NO_AUTH_HEADERS)
     except (cloudflare.APIConnectionError, cloudflare.APIStatusError) as e:
         log_error_and_exit(f"Error getting CloudFlare IPs: {e}")
 

--- a/tests/test_cloudflare.py
+++ b/tests/test_cloudflare.py
@@ -15,6 +15,28 @@ from cf_ips_to_hcloud_fw.models import CloudflareCIDRs
 
 
 @patch("cloudflare.Cloudflare")
+def test_cf_ips_list_sends_no_credentials(mock_cloudflare: MagicMock) -> None:
+    """ips.list is public: build the client with no key and omit auth headers."""
+    sentinel = object()
+    mock_cloudflare.return_value.ips.list.return_value = sentinel
+
+    result = cf_ips_list()
+
+    assert result is sentinel
+    # No api_key/api_token/etc. is passed to the client constructor.
+    mock_cloudflare.assert_called_once_with()
+    _, kwargs = mock_cloudflare.return_value.ips.list.call_args
+    headers = kwargs["extra_headers"]
+    assert set(headers) == {
+        "Authorization",
+        "X-Auth-Email",
+        "X-Auth-Key",
+        "X-Auth-User-Service-Key",
+    }
+    assert all(isinstance(value, cloudflare.Omit) for value in headers.values())
+
+
+@patch("cloudflare.Cloudflare")
 @patch("logging.error")
 def test_cf_ips_list_api_connection_error(
     mock_logging: MagicMock, mock_cloudflare: MagicMock


### PR DESCRIPTION
## Description

`ips.list` is a public Cloudflare endpoint that needs no credentials. The client
was constructed with a placeholder `api_key="dummy"` purely to satisfy the SDK's
credential check, which then sent a bogus `Authorization` header on the wire.

This constructs the client with no key and explicitly omits the auth headers via
the SDK's `Omit` sentinel, so the request carries no credential at all — which is
also what the SDK's own error guidance recommends for unauthenticated calls.

## Motivation

Removes a confusing workaround (a fake "dummy" secret in the source) and stops
sending a meaningless credential header for what is a public request.

## Changes Made

- Build `cloudflare.Cloudflare()` with no key and call
  `ips.list(extra_headers=...)` with `Authorization`, `X-Auth-Email`,
  `X-Auth-Key`, and `X-Auth-User-Service-Key` set to `Omit()`.
- Added a test asserting the client is constructed with no credentials and the
  auth headers are omitted.

## Security

No credential is sent for the public `ips.list` call; previously a placeholder
`Authorization` header was transmitted. No tokens are involved in this endpoint.

## Testing

`make check` — ruff + ty clean, 70 passed, 100% coverage. Also verified
end-to-end against the live endpoint with no Cloudflare env vars set: the
unauthenticated fetch returns the current IP ranges.