### PR TITLE
build(docker): bump final image to alpine 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/
 EOF
 
 
-FROM public.ecr.aws/docker/library/python:3.14.6-alpine3.23@sha256:02da11a8d221ca167aa07de20b3cd7104c1f01227f4b02b1fa13cf6517280a81 AS final-image
+FROM public.ecr.aws/docker/library/python:3.14.6-alpine3.24@sha256:003970a263347645cd23d4f90929ad16ba7ce7d808ee4674ffcc93cb21cc289f AS final-image
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Description

Bumps the Docker final runtime image from Python 3.14.6 on Alpine 3.23 to Python 3.14.6 on Alpine 3.24.

## Motivation

Keeps the container runtime base image current with the latest Alpine release available for the pinned Python image.

## Changes Made

- Updated the final-image stage base image tag and digest in `Dockerfile`.

## Security

No changes to token handling, secret handling, or firewall rule computation/application.

## Testing

`make check` — ruff passed, ty passed, 70 pytest tests passed, 100% coverage.

## Documentation

No documentation changes needed.