### PR TITLE
feat(config): use newline separator for HCLOUD_FIREWALLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Added an environment-variable configuration mode for the common single-project
   case: when `-c/--config` is omitted, the tool uses a `config.yaml` in the
   working directory if present, otherwise builds one project from `HCLOUD_TOKEN`
-  and a comma-separated `HCLOUD_FIREWALLS` list. Docker and Kubernetes users can
+  and a newline-separated `HCLOUD_FIREWALLS` list (one firewall name per line, so
+  names may contain commas and spaces). Docker and Kubernetes users can
   now pass the token as a native secret without mounting a config file, and the
   container image's default command works for both file-mounted and env-var
   setups. Passing `-c` keeps that file as the sole source

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ command override is needed:
 ```shell
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
-  -e HCLOUD_FIREWALLS=firewall-1,firewall-2 \
+  -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
   jkreileder/cf-ips-to-hcloud-fw:1.2.1
 ```
 
@@ -250,7 +250,9 @@ containers:
             name: cf-ips-to-hcloud-fw-token
             key: token
       - name: HCLOUD_FIREWALLS
-        value: firewall-1,firewall-2
+        value: |
+          firewall-1
+          firewall-2
 ```
 
 ## Configuration
@@ -305,12 +307,13 @@ single project from:
 
 - `HCLOUD_TOKEN`: API token with read-write permissions for the Hetzner Cloud
   project.
-- `HCLOUD_FIREWALLS`: comma-separated list of firewall names to update (for
-  example `fw-1,fw-2`).
+- `HCLOUD_FIREWALLS`: newline-separated list of firewall names to update, one
+  name per line. Newlines are used as the separator so names may contain commas
+  and spaces (for example `ICMP, SSH 222 IPv6, Cloudflare`).
 
 ```shell
 export HCLOUD_TOKEN=your-api-token
-export HCLOUD_FIREWALLS=firewall-1,firewall-2
+export HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2'
 cf-ips-to-hcloud-fw
 ```
 

--- a/src/cf_ips_to_hcloud_fw/config.py
+++ b/src/cf_ips_to_hcloud_fw/config.py
@@ -89,8 +89,10 @@ def _read_config_from_env() -> list[Project]:
     """Build a single-project config from environment variables.
 
     Used when no config file is given. Reads the API token from ``HCLOUD_TOKEN``
-    and a comma-separated firewall list from ``HCLOUD_FIREWALLS``, so the common
-    single-project Docker/Kubernetes case needs no config file on disk.
+    and a newline-separated firewall list from ``HCLOUD_FIREWALLS``, so the common
+    single-project Docker/Kubernetes case needs no config file on disk. Newlines
+    are used as the separator because firewall names may contain commas and
+    spaces but never newlines.
 
     Returns:
         list[Project]: A single-element list with the env-derived project.
@@ -100,16 +102,18 @@ def _read_config_from_env() -> list[Project]:
         log_error_and_exit(
             f"No configuration found and {ENV_TOKEN} is not set; provide -c "
             f"CONFIGFILE or a {DEFAULT_CONFIG_FILE!r} file, or set {ENV_TOKEN} "
-            f"and {ENV_FIREWALLS}."
+            f"and {ENV_FIREWALLS} (one firewall name per line)."
         )
 
     firewalls = [
-        fw.strip() for fw in os.environ.get(ENV_FIREWALLS, "").split(",") if fw.strip()
+        fw.strip()
+        for fw in os.environ.get(ENV_FIREWALLS, "").splitlines()
+        if fw.strip()
     ]
     if not firewalls:
         log_error_and_exit(
-            f"{ENV_FIREWALLS} is empty; set it to a comma-separated list of "
-            "firewall names (for example 'fw-1,fw-2')."
+            f"{ENV_FIREWALLS} is empty; set it to a newline-separated list of "
+            "firewall names (one name per line)."
         )
 
     return [Project(token=SecretStr(token), firewalls=firewalls)]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -353,11 +353,11 @@ def test_read_config_validation_error_redacts_secret_value(
 
 @patch.dict(
     "os.environ",
-    {"HCLOUD_TOKEN": "env-token", "HCLOUD_FIREWALLS": "fw-1,fw-2"},
+    {"HCLOUD_TOKEN": "env-token", "HCLOUD_FIREWALLS": "fw-1\nfw-2"},
     clear=True,
 )
 def test_read_config_from_env() -> None:
-    """A token and comma-separated firewall list build a single project."""
+    """A token and newline-separated firewall list build a single project."""
     projects = _read_config_from_env()
     assert projects == [
         Project(token=SecretStr("env-token"), firewalls=["fw-1", "fw-2"])
@@ -366,14 +366,33 @@ def test_read_config_from_env() -> None:
 
 @patch.dict(
     "os.environ",
-    {"HCLOUD_TOKEN": "env-token", "HCLOUD_FIREWALLS": " fw-1 , ,fw-2 ,"},
+    {"HCLOUD_TOKEN": "env-token", "HCLOUD_FIREWALLS": " fw-1 \n \nfw-2 \n"},
     clear=True,
 )
 def test_read_config_from_env_trims_and_filters_firewalls() -> None:
-    """Whitespace is trimmed and empty entries dropped from the firewall list."""
+    """Whitespace is trimmed and blank lines dropped from the firewall list."""
     projects = _read_config_from_env()
     assert projects == [
         Project(token=SecretStr("env-token"), firewalls=["fw-1", "fw-2"])
+    ]
+
+
+@patch.dict(
+    "os.environ",
+    {
+        "HCLOUD_TOKEN": "env-token",
+        "HCLOUD_FIREWALLS": "ICMP, SSH 222 IPv6, Cloudflare\nfw-2",
+    },
+    clear=True,
+)
+def test_read_config_from_env_keeps_commas_and_spaces_in_names() -> None:
+    """Firewall names may contain commas and spaces; newlines separate entries."""
+    projects = _read_config_from_env()
+    assert projects == [
+        Project(
+            token=SecretStr("env-token"),
+            firewalls=["ICMP, SSH 222 IPv6, Cloudflare", "fw-2"],
+        )
     ]
 
 
@@ -403,7 +422,7 @@ def test_read_config_from_env_missing_firewalls(mock_logging: MagicMock) -> None
 
 @patch.dict(
     "os.environ",
-    {"HCLOUD_TOKEN": "SUPER_SECRET_TOKEN_VALUE", "HCLOUD_FIREWALLS": " , "},
+    {"HCLOUD_TOKEN": "SUPER_SECRET_TOKEN_VALUE", "HCLOUD_FIREWALLS": " \n \n "},
     clear=True,
 )
 @patch("logging.error")


### PR DESCRIPTION
## Description

`HCLOUD_FIREWALLS` previously split on commas, so a firewall name that itself
contains commas or spaces — e.g. `ICMP, SSH 222 IPv6, Cloudflare` — was shredded
into several bogus names. This switches the separator to newlines (one name per
line), which firewall names never contain, so no escaping or quoting is needed
and the parse stays unambiguous.

The env-var config mode is unreleased, so there is no compatibility break.

## Changes Made

- `config.py`: split `HCLOUD_FIREWALLS` on `splitlines()` instead of `,`; update
  the docstring and the empty/missing error messages.
- Tests: switch env tests to newlines, add a regression test that a name with
  commas and spaces survives intact, and fix the blank-firewalls test (its old
  `" , "` value would now be a valid single name).
- Docs: README (shell `$'fw-1\nfw-2'`, k8s `value: |` block, variable
  description) and the unreleased CHANGELOG entry.

## Testing

- `make check` — ruff + ty clean, 71 passed, 100% coverage.