### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ debug logs).
 
 **Environment**<!-- markdownlint-disable-line MD036 -->
 
-- cf-ips-to-hcloud-fw version: [e.g. 1.2.1]
+- cf-ips-to-hcloud-fw version: [e.g. 1.3.0]
 - Deployment method: [e.g. Docker, Python module]
 - If Python module, Python version: [e.g. 3.14]
 - If Python module, OS: [e.g. macOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.3.0] – Unreleased
+## [v1.3.0] – 2026-06-14
 
 - Added an environment-variable configuration mode for the common single-project
   case: when `-c/--config` is omitted, the tool uses a `config.yaml` in the
@@ -29,6 +29,7 @@
   digest pinning)
 - Pinned the remaining build-tooling images (binfmt, BuildKit, uv) by digest so
   the signed multi-arch build is fully reproducible
+- Bumped the final container image base to Alpine 3.24
 - Streamlined CI and contributor tooling: prek-based pre-commit runner,
   concurrency limits and job timeouts, and fewer Docker Hub pulls / duplicate
   PR builds

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.2.1
+  jkreileder/cf-ips-to-hcloud-fw:1.3.0
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -155,15 +155,15 @@ command override is needed:
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
   -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
-  jkreileder/cf-ips-to-hcloud-fw:1.2.1
+  jkreileder/cf-ips-to-hcloud-fw:1.3.0
 ```
 
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 `linux/arm64` architectures.  The Docker images support the following tags:
 
 - `1`: This tag always points to the latest `1.x.x` release.
-- `1.2`: This tag always points to the latest `1.2.x` release.
-- `1.2.1`: This tag points to the specific `1.2.1` release.
+- `1.3`: This tag always points to the latest `1.3.x` release.
+- `1.3.0`: This tag points to the specific `1.3.0` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -215,7 +215,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.2.1
+              image: jkreileder/cf-ips-to-hcloud-fw:1.3.0
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false
@@ -242,7 +242,7 @@ falls back to these variables:
 ```yaml
 containers:
   - name: cf-ips-to-hcloud-fw
-    image: jkreileder/cf-ips-to-hcloud-fw:1.2.1
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.0
     env:
       - name: HCLOUD_TOKEN
         valueFrom:
@@ -362,7 +362,7 @@ attest get` after verifying build provenance.
 
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.2.1
+VERSION=1.3.0
 
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
@@ -390,7 +390,7 @@ Build provenance:
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
 IMAGE_REPO=docker.io/jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.2.1
+VERSION=1.3.0
 IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 
 # Verifying build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.3.0.dev1"
+version = "1.3.0"
 dependencies = [
     "cloudflare>=5.3.0",
     "hcloud>=2.21.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.3.0.dev1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Release v1.3.0.

- Bumps `pyproject.toml` (and `uv.lock`) to `1.3.0`.
- Dates the `v1.3.0` CHANGELOG entry (2026-06-14) and adds the Alpine 3.24
  base-image bump.
- Updates pinned `1.2.1` → `1.3.0` references in `README.md` and the bug-report
  issue template.

Tag-driven publish runs on the `v1.3.0` tag after this merges.