### PR TITLE
chore: start new development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- markdownlint-disable MD024 -->
 
+## [v1.3.1] – Unreleased
+
+- Start new development cycle
+
 ## [v1.3.0] – 2026-06-14
 
 - Added an environment-variable configuration mode for the common single-project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.3.0"
+version = "1.3.1.dev1"
 dependencies = [
     "cloudflare>=5.3.0",
     "hcloud>=2.21.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.3.0"
+version = "1.3.1.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Begin v1.3.1 development. Bumps version to `1.3.1.dev1` and opens a fresh `v1.3.1` Unreleased CHANGELOG section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Initialized development cycle for version 1.3.1 with updated project metadata and changelog entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->