### PR TITLE
ci(dockerhub): sync README to Docker Hub description

### DIFF
--- a/.github/workflows/dockerhub-description.yaml
+++ b/.github/workflows/dockerhub-description.yaml
@@ -2,23 +2,13 @@ name: Update Docker Hub description
 
 # Syncs README.md to the Docker Hub repository's full description.
 #
-# TESTING PHASE: runs on PRs so we can confirm the Docker Hub token has the
-# right scope and the description actually updates. Note that there is no
-# staging copy and no dry-run -- every run overwrites the LIVE Docker Hub
-# description with that branch's README (last run wins until the next push).
-#
-# Once verified, switch the `pull_request` trigger to publish on release only:
-#
-#   on:
-#     workflow_dispatch:
-#     push:
-#       tags:
-#         - "v*"
+# Publishes on release (v* tags) so the live description tracks the released
+# README. Use workflow_dispatch to push the current branch's README manually.
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - "main"
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: read
@@ -32,8 +22,6 @@ jobs:
     name: Update Docker Hub description
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Forked PRs have no access to secrets; skip bot PRs too.
-    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
     permissions:
       contents: read
 

--- a/.github/workflows/dockerhub-description.yaml
+++ b/.github/workflows/dockerhub-description.yaml
@@ -1,0 +1,62 @@
+name: Update Docker Hub description
+
+# Syncs README.md to the Docker Hub repository's full description.
+#
+# TESTING PHASE: runs on PRs so we can confirm the Docker Hub token has the
+# right scope and the description actually updates. Note that there is no
+# staging copy and no dry-run -- every run overwrites the LIVE Docker Hub
+# description with that branch's README (last run wins until the next push).
+#
+# Once verified, switch the `pull_request` trigger to publish on release only:
+#
+#   on:
+#     workflow_dispatch:
+#     push:
+#       tags:
+#         - "v*"
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dockerhub-description:
+    name: Update Docker Hub description
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Forked PRs have no access to secrets; skip bot PRs too.
+    if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            hub.docker.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ vars.DOCKERHUB_USERNAME }}/cf-ips-to-hcloud-fw
+          readme-filepath: ./README.md

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ rules up-to-date with the current Cloudflare IP ranges.
 `cf-ips-to-hcloud-fw` fetches the current [Cloudflare IP
 ranges](https://www.cloudflare.com/ips/) and updates your Hetzner Cloud firewall
 rules using the [hcloud
-API](https://docs.hetzner.cloud/#firewall-actions-set-rules).
+API](https://docs.hetzner.cloud/reference/cloud#tag/firewall-actions/set_firewall_rules).
 
 The tool specifically targets **incoming** firewall rules and **replaces** the
 networks with Cloudflare networks if their description contains
@@ -406,10 +406,12 @@ docker scout attest get $IMAGE $DIGEST --predicate-type https://spdx.dev/Documen
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md) for
-guidelines on how to contribute to this project.
+Contributions are welcome! Please see
+[CONTRIBUTING.md](https://github.com/jkreileder/cf-ips-to-hcloud-fw?tab=contributing-ov-file#contributing-guidelines)
+for guidelines on how to contribute to this project.
 
 ## Security
 
-If you discover a security vulnerability, please see [SECURITY.md](SECURITY.md) for
-responsible disclosure instructions.
+If you discover a security vulnerability, please see
+[SECURITY.md](https://github.com/jkreileder/cf-ips-to-hcloud-fw?tab=security-ov-file#reporting-security-issues)
+for responsible disclosure instructions.


### PR DESCRIPTION
## Summary

Adds a workflow that pushes `README.md` to the Docker Hub repository's full
description via the Docker Hub API. Docker Hub stores that field separately and
does not pull it from GitHub, so it needs an explicit API call.

Also fixes the README links that broke outside GitHub: the hcloud firewall-rules
link now points at the current reference URL, and the Contributing/Security links
are absolute so they resolve on Docker Hub.

## Verified

Tested via `workflow_dispatch` — the live Docker Hub description updated, so
`secrets.DOCKERHUB_TOKEN` has the required scope.

## Trigger

Now runs on `v*` tag pushes (release) plus `workflow_dispatch` for manual runs.