### PR TITLE
docs(cut-release): default next dev cycle to patch bump

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -153,9 +153,11 @@ gh release edit vX.Y.Z --draft=false   # after verifying notes & assets
 ### 10. Start the next dev cycle (via a second PR)
 
 Once the release is published, open another PR (again, not a direct push to
-`main`): bump `pyproject.toml` to the next dev version (e.g. `1.4.0.dev1`) and
-add a fresh `## [vNEXT] – Unreleased` heading at the top of `CHANGELOG.md` with
-a `- Start new development cycle` bullet.
+`main`): bump `pyproject.toml` to the next dev version — **default to the next
+patch** (e.g. after releasing `1.3.0`, use `1.3.1.dev1`; escalate to a
+minor/major dev version later only if the work warrants it) — and add a fresh
+`## [vNEXT] – Unreleased` heading at the top of `CHANGELOG.md` with a
+`- Start new development cycle` bullet.
 
 ```bash
 git switch -c chore/start-vNEXT-dev-cycle


### PR DESCRIPTION
## Description
Updates step 10 of the `cut-release` skill so the next dev-cycle example
defaults to a patch bump instead of a minor bump.

## Changes Made
- Change the post-release dev version example from `1.4.0.dev1` to `1.3.1.dev1`
  (after releasing `1.3.0`).
- Note that escalating to a minor/major dev version happens later only if the
  work warrants it.

## Testing
Docs-only change to a skill file (not exercised by CI). pre-commit hooks
(markdownlint, etc.) passed on commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release cycle versioning guidance to default to patch version increments (e.g., 1.3.1.dev1) when starting the next development cycle, along with changelog entry instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->