### PR TITLE
ci: enforce ruff format check in CI, Makefile, and Docker build

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -101,6 +101,9 @@ jobs:
       - name: Lint (ruff)
         run: uv run --no-sync ruff check --output-format=github
 
+      - name: Format check (ruff)
+        run: uv run --no-sync ruff format --check
+
       - name: Type check (ty)
         run: uv run --no-sync ty check --output-format=github
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/
     set -eux
     uv sync --link-mode copy --group dev --frozen
     uv run --no-sync ruff check --output-format=github
+    uv run --no-sync ruff format --check
     uv run --no-sync ty check --output-format=github
     uv run --no-sync pytest
     uv build

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ sync: $(SYNC_STAMP)
 .PHONY: lint
 lint: $(SYNC_STAMP)
 	$(UV) run $(UV_RUN_FLAGS) ruff check
+	$(UV) run $(UV_RUN_FLAGS) ruff format --check
 	$(UV) run $(UV_RUN_FLAGS) ty check
 
 .PHONY: test


### PR DESCRIPTION
## Description

Formatting was only enforced through the opt-in `pre-commit` hook, which a
contributor can bypass with `git commit --no-verify` or skip entirely by never
running `pre-commit install`. CI, the Makefile `lint` target, and the Docker
builder ran `ruff check` and `ty` but never checked formatting — so unformatted
code could land.

This adds a non-mutating `ruff format --check` alongside the existing
`ruff check` in all three places, giving formatting the same backstop as linting
and type checking.

## Changes Made

- **Makefile** `lint`: add `ruff format --check` between `ruff check` and `ty check`.
- **CI** (`python-package.yaml`): add a "Format check (ruff)" step after the lint step.
- **Dockerfile** builder: add `ruff format --check` to the lint/test triad.

## Notes

- `--check` is read-only and exits non-zero on any diff, so no
  `--exit-non-zero-on-fix` is needed (that flag is `ruff check --fix`-only).
- `--output-format=github` is omitted because `ruff format` does not support it.

## Testing

- `make check` — 71 passed, 100% coverage (lint with the new format check passes;
  existing tree already formatted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code formatting verification checks to build pipelines and development workflow validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->