### PR TITLE
ci: add actionlint pre-commit hook

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -29,10 +29,15 @@ jobs:
           egress-policy: block
           # prek pulls hook environments: PyPI (python hooks + uv, pinned via
           # PREK_UV_SOURCE below), npm + nodejs (markdownlint), Go proxy + sumdb
-          # storage (gitleaks), and GitHub.
+          # storage (gitleaks, actionlint), GitHub, and the Go toolchain itself
+          # (go.dev redirect -> dl.google.com tarball) — actionlint's go.mod
+          # needs Go >= 1.25, newer than the runner's preinstalled Go, so prek
+          # downloads a toolchain to build it from source.
           allowed-endpoints: >
+            dl.google.com:443
             files.pythonhosted.org:443
             github.com:443
+            go.dev:443
             nodejs.org:443
             proxy.golang.org:443
             pypi.org:443

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Generate hashes
         id: hash
         if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') && matrix.python-version == '3.11' }}
-        run: cd dist && echo "hashes=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
+        run: cd dist && echo "hashes=$(sha256sum -- * | base64 -w0)" >> "$GITHUB_OUTPUT"
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,13 @@ repos:
     rev: 996abf60411a8d954288ac9856aae7602b80cbda  # frozen: v0.22.1
     hooks:
       - id: markdownlint-cli2
+  - repo: https://github.com/rhysd/actionlint
+    rev: 914e7df21a07ef503a81201c76d2b11c789d3fca  # frozen: v1.7.12
+    hooks:
+      # Lints GitHub Actions workflows; runs shellcheck on run: blocks when
+      # shellcheck is on PATH (CI's ubuntu runner ships it). Degrades to
+      # YAML/expression checks otherwise.
+      - id: actionlint
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: fc6e02dbbb68cbedb18280a47cd73e7cc6769e8d  # frozen: 43.222.1
     hooks:


### PR DESCRIPTION
## Description
Adds the [`rhysd/actionlint`](https://github.com/rhysd/actionlint) hook to
`.pre-commit-config.yaml` (frozen at `v1.7.12`) to lint GitHub Actions
workflows. When `shellcheck` is on PATH it also lints the shell in `run:`
blocks; the CI `ubuntu-latest` runner ships `shellcheck`, so workflow shell
is checked in CI.

## Changes Made
- Add `rhysd/actionlint` pre-commit hook, pinned to a frozen rev (`v1.7.12`),
  matching the repo's existing pinning style.
- Fix the two findings actionlint surfaced on the SLSA hash step in
  `python-package.yaml`:
  - quote `$GITHUB_OUTPUT` (SC2086)
  - `sha256sum -- *` instead of `sha256sum *` (SC2035)

## Notes on the release-critical change
The hash step feeds the SLSA generator's `base64-subjects`. I verified that
`sha256sum -- *` produces **byte-identical** base64 output to the old
`sha256sum *`, so the recorded provenance subjects are unchanged. The naive
`./*` fix was rejected because it would prefix the subject filenames with
`./`.

## Testing
- `make check` — 71 passed, 100% coverage
- `prek run actionlint --all-files` — Passed across all workflows (with
  shellcheck active locally)