### PR TITLE
ci: pin runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   analyze-python:
     name: Analyze Python code with CodeQL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
       actions: read
@@ -88,7 +88,7 @@ jobs:
 
   analyze-actions:
     name: Analyze GitHub actions code with CodeQL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       actions: read

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   docker:
     name: Docker build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     permissions:
       contents: read

--- a/.github/workflows/dockerhub-description.yaml
+++ b/.github/workflows/dockerhub-description.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   dockerhub-description:
     name: Update Docker Hub description
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   prek:
     name: Run pre-commit hooks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   publish-test-results:
     name: Publish test results
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
 

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   upload-event-file:
     name: Upload event file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Harden runner
@@ -38,7 +38,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
@@ -195,7 +195,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - provenance-and-draft-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment:
       name: test-pypi
@@ -234,7 +234,7 @@ jobs:
     needs:
       - provenance-and-draft-release
       - publish-to-test-pypi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     environment:
       name: pypi
@@ -270,7 +270,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - publish-to-pypi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       # Needed to upload the results to code-scanning dashboard.

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   trufflehog:
     name: Secret scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/uv-dependency-submission.yaml
+++ b/.github/workflows/uv-dependency-submission.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   dependency-submission:
     name: Submit uv dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: write # needs to submit dependency graph data


### PR DESCRIPTION
## Description
Replace `ubuntu-latest` with the explicit `ubuntu-24.04` label across all
workflows. `ubuntu-latest` currently resolves to 24.04, so this is a
zero-behavior-change pin — its purpose is to stop GitHub's silent alias
migration (eventually to 26.04) from landing an unannounced runner change on
`main`.

## Motivation
Consistent with the repo's pin-and-bump policy (digests, binfmt, buildkit are
all pinned and Renovate-managed). Renovate's `github-actions` manager tracks the
`github-runners` datasource, so future OS bumps arrive as reviewable PRs whose CI
run validates the new image before merge — rather than appearing silently.

`ubuntu-26.04` is currently public preview only (announced 2026-06-11, no SLA),
so it is intentionally not adopted here; Renovate will propose it once GA.

## Changes Made
- Pinned all 15 `runs-on: ubuntu-latest` occurrences across 10 workflows to
  `ubuntu-24.04`.

## Testing
- `prek run actionlint --all-files` — Passed.