### PR TITLE
ci: smoke test built wheel and Docker image

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -138,6 +138,11 @@ jobs:
           rm -rf dist
           uv build
 
+      - name: Smoke test built wheel
+        run: |
+          uv run --isolated --no-project --with dist/*.whl \
+            cf-ips-to-hcloud-fw --version
+
       - name: Generate SBOM
         if: ${{ matrix.python-version == '3.11' }}
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,10 @@ RUN --mount=type=bind,from=uv-tools-alpine,source=/usr/local/bin/uv,target=/usr/
 
 USER 65534
 
+# Smoke test: confirm the installed entry point runs in the final image before
+# it is pushed, signed, and scanned. Runs per-arch during the buildx build.
+RUN [".venv/bin/cf-ips-to-hcloud-fw", "--version"]
+
 # No -c: the tool auto-detects ./config.yaml (mount it at /usr/src/app/config.yaml)
 # and otherwise falls back to the HCLOUD_TOKEN / HCLOUD_FIREWALLS env vars.
 CMD [".venv/bin/cf-ips-to-hcloud-fw"]


### PR DESCRIPTION
## Description
Tests currently run only against the editable source install (`uv sync` →
`pytest`), so a class of packaging-only defects is never exercised before
publishing: a broken `[project.scripts]` entry point, a module that imports from
`src/` but isn't included in the wheel, or an Alpine/musl runtime problem in the
shipped image (the final stage installs the wheel with `--no-deps` and never runs
it, on a different interpreter than the glibc/Trixie test stage).

This adds two lightweight, zero-side-effect smoke tests using the existing
`--version` flag (no tokens, no network — compatible with the hardened-runner
egress block).

## Changes Made
- **PyPI wheel** — new `Smoke test built wheel` step in the `build` job, run
  across the full 3.10–3.14 matrix right after `uv build`:
  `uv run --isolated --no-project --with dist/*.whl cf-ips-to-hcloud-fw --version`.
  `--isolated --no-project` forces resolution of the console script from the
  installed wheel, not the source tree.
- **Docker image** — exec-form `RUN [".venv/bin/cf-ips-to-hcloud-fw", "--version"]`
  in the Dockerfile's final stage, after `USER 65534`. Runs per-arch during the
  buildx build (arm64 under QEMU), so a broken entry point fails the build before
  the image is pushed, signed, attested, and scanned. Tests the exact `CMD` path
  as the runtime user.

## Testing
- `make check` — 71 passed, 100% coverage.
- `actionlint` (pre-commit) on the workflow — passed.
- `docker buildx build --check` — no warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced automated validation steps in the build pipeline to verify package installation and CLI functionality across deployment environments before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->