### PR TITLE
ci: set explicit retention for uploaded artifacts

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           name: event-file
           path: ${{ github.event_path }}
+          retention-days: 5
 
   build:
     name: Build
@@ -116,6 +117,7 @@ jobs:
         with:
           name: test-results-${{ matrix.python-version }}
           path: test-results.xml
+          retention-days: 14
 
       - name: Upload test results to Codecov
         if: always()
@@ -177,6 +179,7 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+          retention-days: 14
 
   provenance-and-draft-release:
     name: Generate provenance and create draft release


### PR DESCRIPTION
## Description

Three artifact uploads in `python-package.yaml` relied on the default 90-day
retention, while `scorecard.yaml` already set `retention-days: 5`. This makes
retention explicit across all uploads to keep Actions storage tidy.

## Changes Made

- `event-file` → `retention-days: 5` (plumbing for the downstream test-results publisher)
- `test-results-<pyver>` → `retention-days: 14` (room to inspect after a flaky failure)
- `python-package-distributions` → `retention-days: 14` (tag-only; redundant with PyPI and the GitHub Release)

No behavioral change: every consumer downloads its artifact well within these windows.

## Testing

`pre-commit run --files .github/workflows/python-package.yaml` — all hooks passed, including actionlint.