### PR TITLE
test(config): exercise permission checks with real files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,6 @@ addopts = [
     "--cov-fail-under=80",
 ]
 
-[tool.coverage.run]
-core = "ctrace" # test_config.py does not work with sysmon and python 3.14 yet
-
 [tool.ruff]
 src = ["src"]
 preview = true

--- a/src/cf_ips_to_hcloud_fw/config.py
+++ b/src/cf_ips_to_hcloud_fw/config.py
@@ -5,6 +5,11 @@ import os
 import stat
 import sys
 
+# coverage.py's sys.monitoring tracer (Python 3.14) calls os.stat while tracing;
+# binding stat under a private name lets tests patch config's own lookup without
+# intercepting those tracer calls. See test_read_config_permission_stat_error.
+from os import stat as _os_stat
+
 import yaml
 from pydantic import SecretStr, TypeAdapter, ValidationError
 
@@ -26,7 +31,7 @@ def _validate_config_permissions(config_file: str) -> None:
         return
 
     try:
-        mode = stat.S_IMODE(os.stat(config_file).st_mode)
+        mode = stat.S_IMODE(_os_stat(config_file).st_mode)
     except OSError as e:
         log_error_and_exit(
             f"Couldn't check permissions of config file {config_file!r}: {e}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import stat
+import os
+from pathlib import Path
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -16,7 +17,7 @@ from cf_ips_to_hcloud_fw.models import Project
 
 @patch("cf_ips_to_hcloud_fw.config.os.name", "posix")
 @patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
-@patch("cf_ips_to_hcloud_fw.config.os.stat")
+@patch("cf_ips_to_hcloud_fw.config._os_stat")
 @patch("logging.error")
 def test_read_config_permission_stat_error(
     mock_logging: MagicMock,
@@ -39,112 +40,100 @@ def test_read_config_permission_stat_error(
     )
 
 
-@patch("cf_ips_to_hcloud_fw.config.os.name", "posix")
-@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
-@patch("cf_ips_to_hcloud_fw.config.os.stat")
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only permission semantics")
 @patch("logging.warning")
 def test_read_config_permissive_read_permissions_warn(
     mock_warning: MagicMock,
-    mock_stat: MagicMock,
-    mock_exists: MagicMock,
+    tmp_path: Path,
 ) -> None:
     """Allow read-only group access (common for mounted secrets) but warn."""
-    mock_stat.return_value = MagicMock(st_mode=stat.S_IFREG | 0o640)
-
-    with patch(
-        "builtins.open",
-        mock_open(
-            read_data="""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
 - token: token
   firewalls:
     - fw-1
 """,
-        ),
-    ):
-        projects = _read_config("config.yaml")
+        encoding="utf-8",
+    )
+    config.chmod(0o640)
+    config_path = str(config)
+
+    projects = _read_config(config_path)
 
     assert projects == [Project(token=SecretStr("token"), firewalls=["fw-1"])]
-    mock_exists.assert_called_once_with("config.yaml")
-    mock_stat.assert_called_once_with("config.yaml")
     mock_warning.assert_called_once_with(
-        "Config file 'config.yaml' permissions are permissive (640); "
+        f"Config file {config_path!r} permissions are permissive (640); "
         "consider owner-only access (for example 600) when possible."
     )
 
 
 @patch("cf_ips_to_hcloud_fw.config.os.name", "nt")
-@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
-@patch("cf_ips_to_hcloud_fw.config.os.stat")
-@patch(
-    "builtins.open",
-    mock_open(
-        read_data="""
-- token: token
-  firewalls:
-    - fw-1
-""",
-    ),
-)
-def test_read_config_permission_check_skipped_on_non_posix(
-    mock_stat: MagicMock,
-    mock_exists: MagicMock,
-) -> None:
+def test_read_config_permission_check_skipped_on_non_posix(tmp_path: Path) -> None:
     """Skip POSIX-only permission checks on non-POSIX systems."""
-    projects = _read_config("config.yaml")
-
-    assert projects == [Project(token=SecretStr("token"), firewalls=["fw-1"])]
-    mock_exists.assert_not_called()
-    mock_stat.assert_not_called()
-
-
-@patch("cf_ips_to_hcloud_fw.config.os.name", "posix")
-@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
-@patch("cf_ips_to_hcloud_fw.config.os.stat")
-@patch(
-    "builtins.open",
-    mock_open(
-        read_data="""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
 - token: token
   firewalls:
     - fw-1
 """,
-    ),
-)
-def test_read_config_secure_permissions(
-    mock_stat: MagicMock,
-    mock_exists: MagicMock,
-) -> None:
-    """Allow owner-only config files to be parsed normally."""
-    mock_stat.return_value = MagicMock(st_mode=stat.S_IFREG | 0o600)
+        encoding="utf-8",
+    )
+    # World/group-writable would be rejected on POSIX; with os.name forced to a
+    # non-POSIX value the check is skipped and the file parses normally.
+    config.chmod(0o666)
 
-    projects = _read_config("config.yaml")
+    projects = _read_config(str(config))
 
     assert projects == [Project(token=SecretStr("token"), firewalls=["fw-1"])]
-    mock_exists.assert_called_once_with("config.yaml")
-    mock_stat.assert_called_once_with("config.yaml")
 
 
-@patch("cf_ips_to_hcloud_fw.config.os.name", "posix")
-@patch("cf_ips_to_hcloud_fw.config.os.path.exists", return_value=True)
-@patch("cf_ips_to_hcloud_fw.config.os.stat")
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only permission semantics")
+def test_read_config_secure_permissions(tmp_path: Path) -> None:
+    """Allow owner-only config files to be parsed normally."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+- token: token
+  firewalls:
+    - fw-1
+""",
+        encoding="utf-8",
+    )
+    config.chmod(0o600)
+
+    projects = _read_config(str(config))
+
+    assert projects == [Project(token=SecretStr("token"), firewalls=["fw-1"])]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only permission semantics")
 @patch("logging.error")
 def test_read_config_group_or_world_writable_permissions_rejected(
     mock_logging: MagicMock,
-    mock_stat: MagicMock,
-    mock_exists: MagicMock,
+    tmp_path: Path,
 ) -> None:
     """Reject config files writable by group/others."""
-    mock_stat.return_value = MagicMock(st_mode=stat.S_IFREG | 0o666)
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+- token: token
+  firewalls:
+    - fw-1
+""",
+        encoding="utf-8",
+    )
+    config.chmod(0o666)
+    config_path = str(config)
 
     with pytest.raises(SystemExit) as e:
-        _read_config("config.yaml")
+        _read_config(config_path)
 
     assert e.value.code == 1
-    mock_exists.assert_called_once_with("config.yaml")
-    mock_stat.assert_called_once_with("config.yaml")
     mock_logging.assert_called_once_with(
-        "Config file 'config.yaml' has insecure permissions (666); "
-        "group/other write bits are not allowed."
+        f"Config file {config_path!r} has insecure permissions "
+        "(666); group/other write bits are not allowed."
     )
 
 


### PR DESCRIPTION
## Description

The config permission-check tests mocked the global `os.stat` and asserted exact
call counts. On Python 3.14, coverage's `sysmon` core calls `os.stat` while
tracing, and that internal call was captured by the mock — so `assert_called_once`
saw two calls and the suite only passed when pinned to the slower `ctrace` core
via a `[tool.coverage.run] core = "ctrace"` workaround.

This reworks the tests to remove the collision at its source and drops the
workaround, so every Python version runs on the faster default `sysmon` core
(verified: coverage 7.14.1 auto-selects `SysMonitor` on 3.14).

## Changes Made

- Rewrite four of the five permission tests to use real `tmp_path` files +
  `chmod`, exercising the actual permission logic instead of mock call-args.
- Guard the POSIX-semantics tests with `skipif(os.name != "posix")` so the suite
  stays green on non-POSIX dev machines (CI runs on Linux).
- Keep the one `OSError`-injection test mocked (a real readable file can't raise
  `OSError` from `stat`); `config.py` binds `os.stat` under a private `_os_stat`
  name and that test patches it, decoupling the mock from the tracer's `os.stat`.
- Remove the `[tool.coverage.run] core = "ctrace"` override.

## Testing

`make check` — ruff + ty clean, 71 passed, 100% coverage. Also confirmed
`tests/test_config.py` passes under explicit `COVERAGE_CORE=sysmon`, and
`make build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to use real filesystem-based testing for permission validation.

* **Chores**
  * Removed coverage configuration settings.
  * Improved internal permission checking mechanism for better test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->