### PR TITLE
ci(docker): pin binfmt image to qemu-v10.2.3-68 tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -130,7 +130,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         with:
-          image: tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          image: tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0


### PR DESCRIPTION
## Description

Pin the `tonistiigi/binfmt` image used by `setup-qemu-action` in `docker.yaml`
to the more specific upstream tag `qemu-v10.2.3-68`. The pinned digest is
unchanged, so this is purely a tag-label update for clarity/traceability.

## Changes Made

- `.github/workflows/docker.yaml`: `qemu-v10.2.3` → `qemu-v10.2.3-68` (same `@sha256:…` digest)

## Testing

No Python code changed; `make check` does not cover this workflow YAML. Pre-commit
hooks ran on commit (actionlint + others) and passed.