### PR TITLE
chore(deps): bump cloudflare, hcloud, ruff, and ty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 version = "1.3.1.dev1"
 dependencies = [
-    "cloudflare>=5.3.0",
-    "hcloud>=2.21.0",
+    "cloudflare>=5.4.0",
+    "hcloud>=2.22.0",
     "pydantic>=2.13.4",
     "pyyaml>=6.0.3",
 ]
@@ -57,8 +57,8 @@ PyPI = "https://pypi.org/project/cf-ips-to-hcloud-fw/"
 [dependency-groups]
 dev = [
     "pytest-cov>=7.1.0",
-    "ruff>=0.15.17",
-    "ty>=0.0.49",
+    "ruff>=0.15.18",
+    "ty>=0.0.51",
 ]
 
 [tool.pytest]

--- a/uv.lock
+++ b/uv.lock
@@ -54,8 +54,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cloudflare", specifier = ">=5.3.0" },
-    { name = "hcloud", specifier = ">=2.21.0" },
+    { name = "cloudflare", specifier = ">=5.4.0" },
+    { name = "hcloud", specifier = ">=2.22.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pyyaml", specifier = ">=6.0.3" },
 ]
@@ -63,8 +63,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = ">=0.15.17" },
-    { name = "ty", specifier = ">=0.0.49" },
+    { name = "ruff", specifier = ">=0.15.18" },
+    { name = "ty", specifier = ">=0.0.51" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Bump lower-bound version requirements for runtime and dev dependencies.

## Changes Made
- `cloudflare` `>=5.3.0` → `>=5.4.0`
- `hcloud` `>=2.21.0` → `>=2.22.0`
- `ruff` `>=0.15.17` → `>=0.15.18`
- `ty` `>=0.0.49` → `>=0.0.51`
- Regenerated `uv.lock` to match.

## Testing
`make check` — ruff + ty clean, 71 passed, 100% coverage.