### PR TITLE
ci(renovate): match binfmt qemu build suffix in version regex

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,7 @@
             "matchStrings": [
                 "image: (?<depName>tonistiigi/binfmt):(?<currentValue>qemu-v[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
             ],
-            "versioningTemplate": "regex:^qemu-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
+            "versioningTemplate": "regex:^qemu-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<build>\\d+))?$"
         },
         {
             "customType": "regex",


### PR DESCRIPTION
## Description

The `tonistiigi/binfmt` image tag became `qemu-v10.2.3-68` (commit 2ffc706),
but the Renovate `versioningTemplate` for that custom manager still ended at the
patch component (`...(?<patch>\d+)$`). The regex therefore no longer matched the
tag, so Renovate could not parse the version and would not compute updates
correctly.

`moby/buildkit` was checked too and needs nothing: it now uses a standard
`v0.31.0` tag that Renovate's default `docker` versioning handles, so it has no
`versioningTemplate`.

## Changes Made

- Add an optional `-(?<build>\d+)` component to the binfmt `versioningTemplate`
  so it matches both `qemu-v10.2.3` and `qemu-v10.2.3-68`. Using `build` (rather
  than `prerelease`) ranks `-68` as a higher build, not a pre-release.

## Testing

- `renovate-config-validator` (via pre-commit) — Passed
- JSON validity check — Passed