### PR TITLE
docs: drop stale Pydantic V1 warning gotcha

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,7 +84,6 @@
 
 ## Gotchas
 
-- Python 3.14 emits a benign Pydantic V1 warning; CI accepts it.
 - Make recipes run under `bash -eu -o pipefail`; avoid zshisms.
 
 - Missing wheels or odd installs? Remove `.venv/` (or `make clean`) then


### PR DESCRIPTION
## Description

The Gotchas section of `copilot-instructions.md` claimed *"Python 3.14 emits a
benign Pydantic V1 warning; CI accepts it."* That assumption is stale and was
removed after empirical verification.

## Changes Made

- Remove the obsolete Pydantic V1 warning bullet from `## Gotchas`.

## Verification

Tested against the locked toolchain (Python 3.14.6, pydantic 2.13.4):

- `uv run pytest -W default` over the full suite — **0** pydantic / V1 /
  deprecation warnings emitted.
- A warnings-capture import that constructs the Pydantic models directly —
  **0** pydantic-related warnings.
- Confirmed no `filterwarnings` / suppression config anywhere depends on the
  note (only reference was the doc line itself).

Gates run on this change: `markdownlint-cli2` Passed; `make check` — 71 passed,
100% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified troubleshooting guidance by removing outdated information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->