### PR TITLE
ci(renovate): automerge dev/build tooling, guard uv majors

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -62,6 +62,7 @@
             "pinDigests": false
         },
         {
+            "automerge": true,
             "description": "Group GitHub Actions minor/patch into one PR; majors get their own PR.",
             "groupName": "github-actions",
             "matchManagers": [
@@ -73,6 +74,7 @@
             ]
         },
         {
+            "automerge": true,
             "description": "Group container/image minor/patch into one PR; majors get their own PR.",
             "groupName": "docker",
             "matchManagers": [
@@ -85,14 +87,11 @@
             ]
         },
         {
-            "description": "Group pre-commit hook minor/patch into one PR; majors get their own PR.",
+            "automerge": true,
+            "description": "Group all pre-commit hook updates into one automerged PR - lint/validate-only tooling that never ships and is fully CI-gated (ruff/ty are local hooks managed via uv.lock, not here; uv-pre-commit rides with the uv group).",
             "groupName": "pre-commit",
             "matchManagers": [
                 "pre-commit"
-            ],
-            "matchUpdateTypes": [
-                "minor",
-                "patch"
             ]
         },
         {
@@ -134,12 +133,25 @@
             ]
         },
         {
+            "automerge": true,
             "description": "Keep uv together in one PR (the setup-uv input, the Docker uv image, and the uv-pre-commit hook).",
             "groupName": "uv",
             "matchPackageNames": [
                 "astral-sh/uv",
                 "astral-sh/uv-pre-commit",
                 "ghcr.io/astral-sh/uv"
+            ]
+        },
+        {
+            "automerge": false,
+            "description": "uv majors (across managers) get their own manual PR; the uv group otherwise has no update-type filter.",
+            "matchPackageNames": [
+                "astral-sh/uv",
+                "astral-sh/uv-pre-commit",
+                "ghcr.io/astral-sh/uv"
+            ],
+            "matchUpdateTypes": [
+                "major"
             ]
         },
         {


### PR DESCRIPTION
## Description

Broadens Renovate automerge to cover dev/build tooling that never ships in the
package or image and is fully CI-gated, so a bad bump fails checks rather than
merging. Previously only `uv (dev)`, digests/pins, and lock file maintenance
automerged; the `github-actions`, `docker`, `pre-commit`, and `uv` tool groups
were grouped but left manual.

## Changes Made

- Automerge minor/patch for the `github-actions`, `docker`, and `uv` tool groups
  (majors still get a manual PR), matching the existing `uv (dev)` treatment.
- Make the `pre-commit` group automerge **all** update types: it covers
  lint/validate-only hooks (pre-commit-hooks, gitleaks, markdownlint-cli2,
  actionlint, renovate-config-validator) that never ship and are CI-gated.
  `ruff`/`ty` are local hooks pinned via `uv.lock`, not this manager, so they are
  unaffected.
- Add a guard rule so `uv` majors across all managers (setup-uv input, Docker
  image, uv-pre-commit hook) still get a manual PR, since the `uv` tool group has
  no update-type filter.
- Runtime (`project.dependencies`) and build-system deps remain manual by design.

All automerge stays gated by the existing `minimumReleaseAge: 3 days`,
`internalChecksFilter: strict`, and CI.

## Testing

- `prek run renovate-config-validator --files .github/renovate.json` — Passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update handling by grouping more routine updates into single auto-merged pull requests.
  * Pre-commit hook updates are now bundled together in one auto-merged update, and major `uv` updates will be opened separately for manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->