### PR TITLE
chore(lint): enable D, DOC, PTH, and TC ruff rule sets

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -103,7 +103,7 @@ jobs:
         run: uv run --no-sync ruff check --output-format=github
 
       - name: Format check (ruff)
-        run: uv run --no-sync ruff format --check
+        run: uv run --no-sync ruff format --check --output-format=github
 
       - name: Type check (ty)
         run: uv run --no-sync ty check --output-format=github

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/
     set -eux
     uv sync --link-mode copy --group dev --frozen
     uv run --no-sync ruff check --output-format=github
-    uv run --no-sync ruff format --check
+    uv run --no-sync ruff format --check --output-format=github
     uv run --no-sync ty check --output-format=github
     uv run --no-sync pytest
     uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ extend-select = [
     "C4",
     "C90",
     "COM",
+    "D",
+    "DOC",
     "E",
     "EM",
     "ERA001",
@@ -107,6 +109,7 @@ extend-select = [
     "PGH",
     "PL",
     "PT",
+    "PTH",
     "PYI",
     "Q",
     "RET",
@@ -117,6 +120,7 @@ extend-select = [
     "SLF",
     "SLOT",
     "T20",
+    "TC",
     "TID",
     "TRY",
     "UP",
@@ -128,8 +132,11 @@ ignore = [
     "E111",
     "E114",
     "E117",
+    "D203",
     "D206",
+    "D213",
     "D300",
+    "D413",
     "LOG015",
     "Q000",
     "Q001",
@@ -144,6 +151,10 @@ ignore = [
 # Tests may exercise module-private helpers directly: assert (S101), access
 # private members (SLF001), and import private names (PLC2701).
 "tests/*" = ["S101", "SLF001", "PLC2701"]
+# config.py intentionally uses os-level file APIs (os.path.exists, os.stat via
+# _os_stat, builtins.open) so tests can patch them; the _os_stat indirection
+# also avoids intercepting the Python 3.14 coverage tracer's own os.stat calls.
+"src/cf_ips_to_hcloud_fw/config.py" = ["PTH110", "PTH116", "PTH123"]
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]

--- a/src/cf_ips_to_hcloud_fw/__init__.py
+++ b/src/cf_ips_to_hcloud_fw/__init__.py
@@ -1,3 +1,5 @@
+"""Sync Cloudflare IP ranges into Hetzner Cloud firewalls."""
+
 from __future__ import annotations
 
 from importlib import metadata

--- a/src/cf_ips_to_hcloud_fw/__main__.py
+++ b/src/cf_ips_to_hcloud_fw/__main__.py
@@ -1,3 +1,5 @@
+"""CLI entry point: parse args, fetch Cloudflare ranges, update firewalls."""
+
 from __future__ import annotations
 
 import argparse

--- a/src/cf_ips_to_hcloud_fw/cloudflare.py
+++ b/src/cf_ips_to_hcloud_fw/cloudflare.py
@@ -1,3 +1,5 @@
+"""Fetch and validate Cloudflare's published IPv4/IPv6 CIDR ranges."""
+
 from __future__ import annotations
 
 import logging

--- a/src/cf_ips_to_hcloud_fw/config.py
+++ b/src/cf_ips_to_hcloud_fw/config.py
@@ -1,3 +1,5 @@
+"""Resolve project definitions from a config file or environment variables."""
+
 from __future__ import annotations
 
 import logging

--- a/src/cf_ips_to_hcloud_fw/custom_logging.py
+++ b/src/cf_ips_to_hcloud_fw/custom_logging.py
@@ -1,3 +1,5 @@
+"""Logging setup and error helpers shared across the package."""
+
 from __future__ import annotations
 
 import logging

--- a/src/cf_ips_to_hcloud_fw/firewall.py
+++ b/src/cf_ips_to_hcloud_fw/firewall.py
@@ -1,3 +1,5 @@
+"""Update Hetzner firewall rules tagged with Cloudflare IP markers."""
+
 from __future__ import annotations
 
 import logging
@@ -17,10 +19,7 @@ CF_ALL = "__CLOUDFLARE_IPS__"
 
 
 class IPVersionTargets(NamedTuple):
-    """
-    Structure holding boolean flags indicating which IP versions (IPv4/IPv6)
-    should be targeted for firewall rule updates.
-    """
+    """Flags for which IP versions (IPv4/IPv6) a firewall rule should target."""
 
     ipv4: bool
     ipv6: bool

--- a/src/cf_ips_to_hcloud_fw/models.py
+++ b/src/cf_ips_to_hcloud_fw/models.py
@@ -1,3 +1,5 @@
+"""Pydantic models for Cloudflare CIDR payloads and project configuration."""
+
 from __future__ import annotations
 
 from ipaddress import IPv4Network, IPv6Network
@@ -6,16 +8,22 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 
 class CloudflareIPNetworks(BaseModel):
+    """Cloudflare CIDRs parsed as IP network objects, used to validate input."""
+
     ipv4_cidrs: list[IPv4Network]
     ipv6_cidrs: list[IPv6Network]
 
 
 class CloudflareCIDRs(BaseModel):
+    """Cloudflare CIDRs kept as strings for writing to firewall rules."""
+
     ipv4_cidrs: list[str]
     ipv6_cidrs: list[str]
 
 
 class Project(BaseModel):
+    """A Hetzner Cloud API token paired with the firewalls it should update."""
+
     model_config = ConfigDict(extra="forbid")
 
     token: SecretStr

--- a/tests/test_cloudflare.py
+++ b/tests/test_cloudflare.py
@@ -1,3 +1,5 @@
+"""Tests for the Cloudflare CIDR fetching and validation module."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,9 @@
+"""Tests for config resolution from files and environment variables."""
+
 from __future__ import annotations
 
 import os
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -13,6 +15,9 @@ from cf_ips_to_hcloud_fw.config import (
     load_projects,
 )
 from cf_ips_to_hcloud_fw.models import Project
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pathlib import Path  # pragma: no cover
 
 
 @patch("cf_ips_to_hcloud_fw.config.os.name", "posix")

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -1,3 +1,5 @@
+"""Tests for the Hetzner firewall rule update logic."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, call, patch

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,3 +1,5 @@
+"""Tests for logging setup and error helpers."""
+
 from __future__ import annotations
 
 import argparse

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,5 @@
+"""Tests for the CLI entry point and argument parsing."""
+
 from __future__ import annotations
 
 import importlib
@@ -74,7 +76,7 @@ def test_parser_version_no_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     return_value=ProjectOutcome(skipped=[], failed=[]),
 )
 def test_main(mock_update_project: MagicMock, mock_projects: MagicMock) -> None:
-    """main should iterate every parsed project and call update_project."""
+    """Iterate every parsed project and call update_project."""
     main()
     assert mock_update_project.call_count == len(mock_projects.return_value)
     for i, project in enumerate(mock_projects.return_value):
@@ -101,7 +103,7 @@ def test_main(mock_update_project: MagicMock, mock_projects: MagicMock) -> None:
 def test_main_with_skipped_firewalls(
     mock_logging: MagicMock, mock_update_project: MagicMock, mock_projects: MagicMock
 ) -> None:
-    """main should exit with code 1 when firewalls are skipped."""
+    """Exit with code 1 when firewalls are skipped."""
     with pytest.raises(SystemExit) as e:
         main()
     assert e.value.code == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+"""Tests for the Pydantic models."""
+
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
## Description

Enables four additional ruff rule sets — `D` (pydocstyle), `DOC` (pydoclint),
`PTH` (flake8-use-pathlib), and `TC` (flake8-type-checking) — and fixes the
resulting violations.

## Changes Made

- Add module/class docstrings across the package and tests (`D`, `DOC`).
- Ignore the incompatible pydocstyle pairs `D203`/`D213`, plus `D413` whose
  trailing-blank-after-section style is absent from the existing docstrings.
- Select `PTH` repo-wide but per-file-ignore `config.py`
  (`PTH110`/`PTH116`/`PTH123`): it intentionally uses os-level file APIs so
  tests can patch them, and the `_os_stat` indirection avoids intercepting the
  Python 3.14 coverage tracer's own `os.stat` calls.
- Move `pathlib.Path` into a `TYPE_CHECKING` block in `test_config.py` (`TC`),
  where it is used only in annotations.
- Emit GitHub annotations from `ruff format --check` in CI (workflow + Docker
  builder).

Note: `G` (flake8-logging-format) was evaluated but intentionally not adopted —
most user-facing messages route through the `log_error`/`log_error_and_exit`
wrappers, which `G004` can't see through, so it would only police a minority of
call sites for no runtime benefit in a fire-once CLI.

## Testing

`make check` — ruff + ty clean, 71 passed, 100% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line entry point for running the sync process directly, with support for configuration, debug mode, and version output.
  * Exposed package version information for easier CLI and runtime checks.

* **Bug Fixes**
  * Improved Ruff formatter output in checks for clearer, GitHub-friendly error reporting.
  * Expanded linting rules and exceptions to better match the project’s code style and documentation standards.

* **Documentation**
  * Added and refreshed module and test descriptions across the project for clearer maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->