### PR TITLE
ci: enforce Conventional Commits in PR titles

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,41 @@
+# Validates that pull request titles follow Conventional Commits.
+#
+# Because merges are squash-only and the repo's squash commit title is set to
+# PR_TITLE, the PR title becomes the commit subject on main — so enforcing it
+# here keeps main's history conventional. Individual commit messages are
+# discarded by the squash, so they are intentionally not linted.
+#
+# Source repository: https://github.com/amannn/action-semantic-pull-request
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Adds a CI check that validates pull request titles against Conventional
Commits, using `amannn/action-semantic-pull-request` (SHA-pinned to v6.1.1).

Because merges are squash-only and the repo's squash commit title is set to
`PR_TITLE`, the PR title becomes the subject line on `main` — so linting it
keeps `main`'s history conventional. This enforces the existing repo
convention ("format PR titles using Conventional Commits") automatically.

Individual commit messages are intentionally **not** linted (no commitlint):
the surfaced history (oneline log, changelog, releases) comes from the PR
title, and per-commit linting would add one-sided friction to human WIP
commits while Renovate/Dependabot already emit clean conventional commits.

## Changes Made

- Add `.github/workflows/pr-title.yaml` — validates PR titles on
  `opened`/`edited`/`reopened`, hardened runner with egress block, action
  SHA-pinned with a `# v6.1.1` comment for Renovate.
- (Repo setting, applied separately) `squash_merge_commit_title` changed
  `COMMIT_OR_PR_TITLE` → `PR_TITLE` so the validated title always becomes the
  squash subject, even for single-commit PRs.

## Testing

- `actionlint` (via prek) — passed.
- pre-commit hooks on commit — passed.