### PR TITLE
ci(docker): pin CloudFront egress to Docker Scout CDN hosts

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,8 +40,11 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: block
+          # The two d*.cloudfront.net hosts are Docker Scout's vulnerability-data
+          # CDN distributions. If Docker rotates them, only the scan steps
+          # (continue-on-error) lose access — update the names from the
+          # harden-runner insights of the failing run.
           allowed-endpoints: >
-            *.cloudfront.net:443
             api.dso.docker.com:443
             api.github.com:443
             api.scout.docker.com:443
@@ -49,6 +52,8 @@ jobs:
             cdn01.quay.io:443
             cdn02.quay.io:443
             cdn03.quay.io:443
+            d2glxqk2uabbnd.cloudfront.net:443
+            d5l0dvt14r5h8.cloudfront.net:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
             files.pythonhosted.org:443
             fulcio.sigstore.dev:443


### PR DESCRIPTION
## Description

Narrow the harden-runner egress allowlist in `docker.yaml`: replace the
`*.cloudfront.net:443` wildcard with the two specific CloudFront
distributions Docker Scout actually contacts.

## Motivation

The wildcard effectively allowed connections to any CloudFront
distribution, which is a viable exfiltration channel for a compromised
dependency — the exact threat `egress-policy: block` exists to stop.

## Changes Made

- Replace `*.cloudfront.net:443` with `d2glxqk2uabbnd.cloudfront.net:443`
  and `d5l0dvt14r5h8.cloudfront.net:443` (identified from harden-runner
  insights telemetry of past runs).
- Add a comment documenting what the hosts are and how to refresh them if
  Docker rotates the distributions.

The failure mode of a stale hostname is soft: only the Scout/Grype scan
steps (`continue-on-error: true`) would lose access; the build and publish
path is unaffected.

## Testing

`make check` — 71 passed, 100% coverage; `actionlint` passed. This PR's own
Docker workflow run exercises the Scout/Grype steps under the narrowed
allowlist and serves as the live validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened the CI workflow’s allowed network endpoints for Docker scanning.
  * Replaced a broad CloudFront allowance with specific endpoints to reduce exposure and improve security.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->