### PR TITLE
ci(python): isolate Codecov uploads in their own job

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -64,25 +64,17 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
-            api.codecov.io:443
             api.github.com:443
-            cli.codecov.io:443
-            codecov.io:443
             files.pythonhosted.org:443
             fulcio.sigstore.dev:443
             get.anchore.io:443
             github.com:443
-            ingest.codecov.io:443
-            keybase.io:443
-            o26192.ingest.us.sentry.io:443
             objects.githubusercontent.com:443
             pypi.org:443
             raw.githubusercontent.com:443
             rekor.sigstore.dev:443
             release-assets.githubusercontent.com:443
             releases.astral.sh:443
-            storage.googleapis.com:443
-            uploader.codecov.io:443
             uploads.github.com:443
 
       - name: Checkout repository
@@ -119,21 +111,16 @@ jobs:
           path: test-results.xml
           retention-days: 14
 
-      - name: Upload test results to Codecov
+      # Separate artifact from test-results-*: publish-test-results.yaml feeds
+      # every XML in test-results-* to the JUnit publisher, which must not see
+      # the Cobertura coverage report.
+      - name: Upload coverage report
         if: always()
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          files: ./test-results.xml
-          flags: python-${{ matrix.python-version }}
-          report_type: test_results
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          files: ./coverage.xml
-          flags: python-${{ matrix.python-version }}
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage-${{ matrix.python-version }}
+          path: coverage.xml
+          retention-days: 14
 
       - name: Build
         run: |
@@ -180,6 +167,83 @@ jobs:
           name: python-package-distributions
           path: dist/
           retention-days: 14
+
+  upload-to-codecov:
+    name: Upload to Codecov
+    # Codecov uploads run in their own job so the third-party uploader only
+    # ever sees the coverage/test-result XML files — never the workspace of
+    # the job that builds and attests release artifacts — and its egress
+    # (including the shared storage.googleapis.com host) stays out of the
+    # build job's allowlist. Runs even when the build job failed so a red
+    # test run still reports its results.
+    if: ${{ !cancelled() }}
+    needs:
+      - build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.codecov.io:443
+            api.github.com:443
+            cli.codecov.io:443
+            codecov.io:443
+            github.com:443
+            ingest.codecov.io:443
+            keybase.io:443
+            o26192.ingest.us.sentry.io:443
+            storage.googleapis.com:443
+            uploader.codecov.io:443
+
+      # The codecov CLI fixes report paths against the source tree.
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # continue-on-error: the artifacts don't exist when the build job died
+      # before pytest (lint/type-check failure); the codecov steps then warn
+      # about the missing files instead of failing, as they did in-job.
+      - name: Download test results
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: test-results-${{ matrix.python-version }}
+
+      - name: Download coverage report
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-${{ matrix.python-version }}
+
+      - name: Upload test results to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./test-results.xml
+          flags: python-${{ matrix.python-version }}
+          report_type: test_results
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage.xml
+          flags: python-${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   provenance-and-draft-release:
     name: Generate provenance and create draft release


### PR DESCRIPTION
## Description

Move the two `codecov-action` invocations out of the `build` job into a
downstream `upload-to-codecov` job that receives only the coverage and
test-result XML artifacts.

## Motivation

Privilege separation for the third-party uploader, same move as
`publish-test-results.yaml`:

- codecov-action no longer executes inside the job that builds and attests
  the release artifacts, so a compromised uploader (cf. Codecov's 2021 bash
  uploader incident) only ever sees XML reports and the low-value upload
  token.
- Eight Codecov-related endpoints leave the build job's harden-runner
  allowlist — notably `storage.googleapis.com`, a shared any-bucket GCS
  host that was the widest remaining egress in that job.

## Changes Made

- Drop `api.codecov.io`, `cli.codecov.io`, `codecov.io`,
  `ingest.codecov.io`, `uploader.codecov.io`, `keybase.io`,
  `o26192.ingest.us.sentry.io`, and `storage.googleapis.com` from the build
  job's egress allowlist.
- Upload `coverage.xml` as a per-version `coverage-*` artifact (kept
  separate from `test-results-*` so the JUnit publisher in
  `publish-test-results.yaml` never sees the Cobertura file).
- Add the `upload-to-codecov` matrix job (`needs: build`,
  `if: !cancelled()`) with a Codecov-only egress allowlist; artifact
  downloads are `continue-on-error` so an early build failure degrades to
  the same missing-file warnings as before.

The new job is intentionally not a required status check; Codecov's own
patch/project checks keep gating PRs. Side effect: coverage now also
uploads when tests fail (previously only test results did), which is a
minor improvement.

## Testing

`make check` — 71 passed, 100% coverage; `actionlint` passed. This PR's own
CI run validates the split end to end: build under the trimmed allowlist,
artifact handoff, and both Codecov uploads from the isolated job.