### PR TITLE
ci: add zizmor workflow security audit and resolve its findings

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -137,8 +137,12 @@ jobs:
         with:
           image: tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
 
+      # GHA cache scopes are branch-isolated: only code already running on
+      # main can write the cache a tag build restores — and a compromised
+      # main build publishes images directly anyway, so the cache adds no new
+      # trust boundary. Disabling it would cost full QEMU rebuilds per release.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 # zizmor: ignore[cache-poisoning]
         with:
           driver-opts: image=moby/buildkit:v0.31.1@sha256:6b59b7df63a8cb9902736f9ddf7fcff8261613d3e7449b8ea8b7537fc399c03a
           version: v0.35.0
@@ -226,8 +230,9 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    # Can't pin with hash: SLSA verification requires calling the generator
+    # by tag, and GitHub evaluates the ref for nested actions inside it too.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       image: ${{ vars.DOCKERHUB_USERNAME }}/cf-ips-to-hcloud-fw
       digest: ${{ needs.docker.outputs.digest }}
@@ -245,8 +250,9 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    # Can't pin with hash: SLSA verification requires calling the generator
+    # by tag, and GitHub evaluates the ref for nested actions inside it too.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       image: quay.io/${{ vars.QUAY_USERNAME }}/cf-ips-to-hcloud-fw
       digest: ${{ needs.docker.outputs.digest }}
@@ -264,8 +270,9 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    # Can't pin with hash: SLSA verification requires calling the generator
+    # by tag, and GitHub evaluates the ref for nested actions inside it too.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       image: ghcr.io/${{ github.repository_owner }}/cf-ips-to-hcloud-fw
       digest: ${{ needs.docker.outputs.digest }}

--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -1,6 +1,10 @@
 name: Publish test results
 
-on:
+# workflow_run is used deliberately (the EnricoMi-documented pattern): fork-PR
+# artifacts are processed here, in a job whose token is limited to
+# checks/pull-requests write and whose egress is locked to api.github.com,
+# instead of granting write permissions to the untrusted PR run itself.
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows:
       - Build, sign, and publish Python package

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -87,6 +87,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           version: "0.11.24"
+          # Keep release builds hermetic: don't restore caches when building
+          # the artifacts that get published (tag pushes).
+          enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Sync dependencies
         run: uv sync --group dev --frozen
@@ -255,8 +258,9 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    # Can't pin with hash: SLSA verification requires calling the generator
+    # by tag, and GitHub evaluates the ref for nested actions inside it too.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       base64-subjects: ${{ needs.build.outputs.hashes }}
       upload-assets: true
@@ -366,7 +370,8 @@ jobs:
       - name: Upload distribution packages to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
         run: >-
           gh release upload
-          '${{ github.ref_name }}' dist/**
+          "$TAG" dist/**
           --repo '${{ github.repository }}'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,13 @@ repos:
       # shellcheck is on PATH (CI's ubuntu runner ships it). Degrades to
       # YAML/expression checks otherwise.
       - id: actionlint
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815  # frozen: v1.26.1
+    hooks:
+      # Security audit of GitHub Actions workflows (template injection,
+      # credential persistence, cache poisoning, ...); complements actionlint,
+      # which checks correctness.
+      - id: zizmor
   - repo: https://github.com/renovatebot/pre-commit-hooks
     rev: ea931ccc70c472cfeb2f822acba7f0e12b7842ce  # frozen: 43.243.1
     hooks:


### PR DESCRIPTION
## Description

Add [zizmor](https://docs.zizmor.sh/) as a pinned pre-commit hook to audit the
GitHub Actions workflows for security issues (template injection, credential
persistence, cache poisoning, dangerous triggers), complementing actionlint's
correctness checks. It runs in the existing pre-commit CI job; the PyPI
install is already covered by that job's egress allowlist.

## Changes Made

Two real fixes:

- **template-injection**: `github.ref_name` in the release-upload script now
  flows through an env var instead of expanding into the `run:` block.
  (Defense in depth — tag creation is already admin-restricted by ruleset.)
- **cache-poisoning (Python build)**: `setup-uv` no longer restores caches on
  tag builds, so published artifacts are built hermetically; PR/branch builds
  keep the cache.

Three accepted risks, annotated inline with rationale:

- **unpinned-uses** on the four SLSA generator calls — SLSA verification
  requires tag refs.
- **cache-poisoning (Docker build)** — GHA cache scopes are branch-isolated
  and a compromised main build could publish images directly, so the cache
  adds no new trust boundary; dropping it would cost full QEMU rebuilds per
  release.
- **dangerous-triggers** on publish-test-results — deliberate `workflow_run`
  privilege-separation pattern with a restricted token and
  api.github.com-only egress.

## Testing

`prek run zizmor --all-files` and `actionlint` pass; `make check` — 71 passed,
100% coverage. The hermetic-release path (`enable-cache` expression) is only
exercised on the next `v*` tag build.