### PR TITLE
ci(docker): build releases without the gha cache

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -137,15 +137,20 @@ jobs:
         with:
           image: tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
 
-      # GHA cache scopes are branch-isolated: only code already running on
-      # main can write the cache a tag build restores — and a compromised
-      # main build publishes images directly anyway, so the cache adds no new
-      # trust boundary. Disabling it would cost full QEMU rebuilds per release.
+      # Release (tag) builds run cache-free for a hermetic commit→image chain,
+      # mirroring the Python workflow. main/PR builds keep the gha cache for
+      # speed: its scopes are branch-isolated (only code already on main can
+      # write what a build restores) and a compromised main build publishes
+      # images directly anyway, so the cache adds no new trust boundary.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0 # zizmor: ignore[cache-poisoning]
         with:
           driver-opts: image=moby/buildkit:v0.31.1@sha256:6b59b7df63a8cb9902736f9ddf7fcff8261613d3e7449b8ea8b7537fc399c03a
           version: v0.35.0
+          # Fetch the buildx binary fresh from the pinned release on tag builds
+          # instead of restoring it from the gha cache (hermetic; the binary is
+          # the builder itself). Keep the cache for main/PR speed.
+          cache-binary: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push
         id: build-and-push
@@ -160,8 +165,8 @@ jobs:
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           annotations: ${{ steps.docker-meta.outputs.annotations }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: ${{ !startsWith(github.ref, 'refs/tags/') && 'type=gha' || '' }}
+          cache-to: ${{ !startsWith(github.ref, 'refs/tags/') && 'type=gha,mode=max' || '' }}
 
       - name: Generate artifact attestation for DockerHub
         if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
## Description

Make released Docker images a hermetic function of the tagged commit by not
restoring any gha cache on tag builds. This mirrors the Python release
workflow, which already disables its cache on tags, and closes the last
cross-run-state link in the commit→image supply chain.

## Changes Made

- Gate `cache-from` / `cache-to` (buildx **layer** cache) on non-tag refs.
- Gate `cache-binary` (the buildx **binary** itself — the builder) on non-tag
  refs, so releases fetch it fresh from the pinned `v0.35.0` release instead of
  a gha-cache blob.
- Rewrite the `Set up Docker Buildx` comment to explain the tag-vs-main split;
  keep the `zizmor: ignore[cache-poisoning]` since main/PR builds still use the
  gha cache (branch-isolated, and a compromised main build publishes directly).

## Notes

main/PR builds keep the cache for feedback speed. Release cost is modest: the
`builder` stage is `FROM --platform=$BUILDPLATFORM`, so the test suite runs once
natively on amd64 — only the arm64 runtime layers rebuild under emulation on
tags.

## Testing

Not runtime-testable locally (CI-only workflow change). Verified via pre-commit:
actionlint and zizmor both pass; diff is limited to the three intended edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build settings so tagged releases run without shared cache data, making release builds more consistent and self-contained.
  * Non-tag builds still use caching to keep regular builds faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->