### PR TITLE
ci(docker): verify uv base image provenance before build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,6 +44,10 @@ jobs:
           # CDN distributions. If Docker rotates them, only the scan steps
           # (continue-on-error) lose access — update the names from the
           # harden-runner insights of the failing run.
+          # tmaproduction.blob.core.windows.net is GitHub's attestation-bundle
+          # storage that `gh attestation verify` fetches from in the base-image
+          # provenance check; if GitHub rotates the storage account, update it
+          # from the failing run's harden-runner insights.
           allowed-endpoints: >
             api.dso.docker.com:443
             api.github.com:443
@@ -77,6 +81,7 @@ jobs:
             rekor.sigstore.dev:443
             release-assets.githubusercontent.com:443
             timestamp.sigstore.dev:443
+            tmaproduction.blob.core.windows.net:443
             tuf-repo-cdn.sigstore.dev:443
             uploads.github.com:443
 
@@ -84,6 +89,34 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      # Verify the uv base images carry astral-sh's signed SLSA build provenance
+      # before building on them — fail closed, so a PR that repins to an
+      # unattested or tampered digest stops the build. Runs before the QEMU/
+      # buildx/login setup to fail fast. Only the uv images are checkable here:
+      # the python base is a Docker Official Image whose inline provenance is
+      # unsigned (no verifiable signer). Refs are read from the Dockerfile so the
+      # pins stay single-sourced; the found guard trips if the pin format drifts
+      # and the grep silently matches nothing.
+      - name: Verify uv base image provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          found=0
+          while IFS= read -r image; do
+            found=1
+            echo "::group::verify $image"
+            gh attestation verify "oci://$image" \
+              --owner astral-sh \
+              --predicate-type https://slsa.dev/provenance/v1
+            echo "::endgroup::"
+          done < <(grep -oE 'ghcr\.io/astral-sh/uv:[^ @]+@sha256:[0-9a-f]{64}' Dockerfile | sort -u)
+          if [ "$found" -eq 0 ]; then
+            echo "::error::No uv base images found in Dockerfile — verification would be a no-op"
+            exit 1
+          fi
 
       - name: Docker meta
         id: docker-meta


### PR DESCRIPTION
## Description

Add a fail-closed step to the Docker build that verifies the uv base images
carry astral-sh's **signed** SLSA build provenance before we build on them.
This closes the base-image verification gap for the part of the base that is
actually verifiable.

Confirmed empirically against the pinned images:

- `ghcr.io/astral-sh/uv` ships GitHub-signed SLSA provenance v1 →
  `gh attestation verify --owner astral-sh` succeeds (both the trixie and
  alpine variants).
- `public.ecr.aws/docker/library/python` (a Docker Official Image) only carries
  **unsigned** inline BuildKit provenance/SBOM — no verifiable signer identity —
  so there is nothing to gate on there. Left as-is; DHI/Chainguard is the option
  if we later want a signed python base.

## Changes Made

- New `Verify uv base image provenance` step, placed before the QEMU/buildx/login
  setup so it fails fast.
- Reads the uv refs straight from the `Dockerfile` (pins stay single-sourced),
  verifies each with `gh attestation verify --owner astral-sh --predicate-type
  https://slsa.dev/provenance/v1`.
- Fail-closed: a repin to an unattested or tampered digest aborts the build. A
  `found` guard also fails the step if the pin format drifts and the grep
  matches nothing (so verification can't silently become a no-op).
- Allow `tmaproduction.blob.core.windows.net` through harden-runner — that is
  where GitHub stores the attestation bundles `gh` downloads during verification
  (the API URL is `api.github.com`, but the bundle body is served from Azure
  Blob). Documented with a rotation note next to the Docker Scout CDN hosts.

## Notes

Fail-closed is deliberate: a verify step that doesn't fail the build isn't a
control. If sigstore/registry flakiness ever causes false failures, the follow-up
is a retry wrapper, not `continue-on-error`.

## Testing

- Local (outside CI): both uv images verify OK; a tampered digest makes the step
  exit non-zero (fail-closed confirmed); extraction + loop run under bash 3.2 and
  bash 5; pre-commit actionlint and zizmor pass.
- CI: the first run failed closed exactly as designed — harden-runner blocked the
  attestation-bundle host. After allowlisting it, the step passes and verifies
  both the alpine and trixie uv images before the build proceeds.