### PR TITLE
docs(template): trim checkbox-heavy PR template

### DIFF
--- a/.claude/skills/ship-changes/SKILL.md
+++ b/.claude/skills/ship-changes/SKILL.md
@@ -121,17 +121,19 @@ agreed).
 ### 8. Open the pull request
 
 Use a Conventional Commits **PR title** (same format as the commit subject).
-Fill the repo's PR template, but keep it lean and honest:
+Fill the repo's PR template (`Summary`, `Security`, `Testing`), keeping it lean
+and honest:
 
-- Write the prose sections (Description, Motivation, Changes Made) accurately.
-- **Don't pre-tick the template's checkboxes.** Those are the *author's*
-  self-certification. The DCO sign-off and the commit signature are already
-  enforced (DCO app + branch protection); the Conventional Commits title is a
-  repo convention you should follow but nothing verifies it automatically.
-  Either way, leave the boxes unchecked for the human to confirm rather than
-  asserting them on their behalf.
-- Report what you actually ran in prose under Testing (e.g. "`make check` —
-  56 passed, 100% coverage") instead of ticking boxes.
+- Write **Summary** to cover what changed and why; link issues with
+  `Fixes #<number>` when one applies.
+- Fill **Security** with the token/secret or firewall-rule impact, or `None`.
+- Report what you actually ran under **Testing** in prose (e.g. "`make check` —
+  56 passed, 100% coverage"). CI already runs lint, type-check, and tests, so
+  don't re-attest to those.
+- Don't self-certify on the author's behalf. The DCO sign-off and commit
+  signature are enforced (DCO app + branch protection) and the Conventional
+  Commits title is enforced by `pr-title.yaml`, so state facts you verified
+  rather than asserting conventions on the human's behalf.
 - Drop sections that don't apply rather than padding them.
 
 ```bash
@@ -139,12 +141,11 @@ gh pr create \
   --base main \
   --title "<type>(<scope>): <subject>" \
   --body "$(cat <<'EOF'
-## Description
-<summary>
+## Summary
+<what changed and why; Fixes #<number> if applicable>
 
-## Changes Made
-- <change 1>
-- <change 2>
+## Security
+<token/secret or firewall-rule impact, or None>
 
 ## Testing
 <what you ran and the result, e.g. `make check` — 56 passed, 100% coverage>

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,11 +70,12 @@
   contributors should install hooks with `pre-commit install` or
   `prek install`.
 - Commit sign-offs — PRs require developer sign-off using `git commit -s`;
-  you can see the PR checklist in `.github/pull_request_template.md`. This is
-  the project DCO requirement. GitHub also enforces cryptographically-signed
-  commits for this repository via branch protection — you must configure
-  GPG/SSH commit signing locally or use the `-S` flag to sign commits if
-  required. Note that package and image artifacts are also cryptographically
+  this is the project DCO requirement, also noted in `.github/CONTRIBUTING.md`
+  and the `.github/pull_request_template.md` header. GitHub also enforces
+  cryptographically-signed commits for this repository via branch protection
+  — you must configure GPG/SSH commit signing locally or use the `-S` flag
+  to sign commits if required. Note that package and image artifacts are also
+  cryptographically
   signed during CI.
 - Commit style — commit messages should follow Conventional Commits
   (`<type>[optional scope]: <description>`), e.g., `fix(auth): resolve login

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,52 +1,20 @@
 <!--
-Thank you for your contribution to cf-ips-to-hcloud-fw!
-
-This PR template helps us review changes consistently. Please fill out all sections
-and verify the checklist before submitting.
+Thanks for contributing to cf-ips-to-hcloud-fw!
+PR titles follow Conventional Commits: <type>[scope]: <description>
+Commits must be signed off (git commit -s) for DCO.
 -->
 <!-- markdownlint-disable MD041 -->
 
-## Description
+## Summary
 
-<!-- Provide a clear summary of the changes in this PR -->
-
-## Motivation
-
-<!-- Why are these changes needed? Link issues with "Fixes #<number>" if applicable -->
-
-## Changes Made
-
-<!-- List the key changes in this PR -->
-
--
--
--
+<!-- What changed and why. Link issues with "Fixes #<number>". -->
 
 ## Security
 
-<!-- Does this change how tokens/secrets are handled, or how firewall rules are
-computed or applied? Describe the impact, or write "None". -->
+<!-- Any change to how tokens/secrets are handled, or how firewall rules
+are computed or applied? Describe the impact, or write "None". -->
 
 ## Testing
 
-<!-- How did you test these changes? CI runs lint, type-check, and tests
-(≥80% coverage) on every PR, so no need to attest to those here. -->
-
-- [ ] Added or updated unit tests
-
-## Documentation
-
-<!-- Mark which documentation has been updated -->
-
-- [ ] README.md updated
-- [ ] Docstrings/comments added or updated
-- [ ] CHANGELOG.md entry added (if user-facing)
-- [ ] No documentation changes needed
-
-## Checklist
-
-- [ ] I have read the [contributing guidelines](.github/CONTRIBUTING.md)
-- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/):
-     `<type>[optional scope]: <description>`
-  - Example: `fix(firewall): resolve rule sync issue` or `chore(deps): bump ruff to v0.14.6`
-- [ ] Commits are signed off with `git commit -s` (required for DCO compliance)
+<!-- How you verified the change. CI already runs lint, type-check, and
+tests (≥80% coverage), so no need to attest to those. -->


### PR DESCRIPTION
## Summary

The pull request template had 11 checkboxes across Testing, Documentation,
and Checklist sections. Most were either self-certification a reviewer can
verify faster than an author can tick, or gates already enforced elsewhere.
This trims it to zero checkboxes:

- Merge **Description + Motivation** into a single **Summary** section.
- Keep **Security** (first-class for this tool) and **Testing** as prose prompts.
- Drop the **Documentation** and **Checklist** sections.
- Move the Conventional Commits + DCO sign-off reminders into the template
  header comment.

## Why the removed checkboxes were safe to drop

- **Conventional Commits title** — enforced by `pr-title.yaml`
  (action-semantic-pull-request); squash merges use the PR title as the commit
  subject, so CI is the real gate.
- **DCO sign-off + verified signatures** — enforced by branch protection.
- Both conventions remain documented in `.github/CONTRIBUTING.md`.

## Follow-on consistency fixes

- Update the stale "PR checklist" reference in `copilot-instructions.md`, which
  no longer exists.
- Align the `ship-changes` skill (step 8) with the new template: reference the
  real sections (Summary/Security/Testing), drop the obsolete "don't pre-tick
  checkboxes" guidance, and fix the \`gh pr create\` example body.

## Testing

Docs-only change. \`prek run markdownlint-cli2\` on all touched files — Passed;
commit pre-commit hooks (markdownlint, gitleaks, whitespace) — all Passed.