### PR TITLE
ci(coverage): raise coverage floor from 80% to 95%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ addopts = [
     "--cov-report=xml",
     "--cov-report=html",
     "--cov-report=term-missing",
-    "--cov-fail-under=80",
+    "--cov-fail-under=95",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

The test suite holds 100% branch coverage (`--cov-branch`) with zero
`# pragma: no cover` waivers, yet the gate only enforced `--cov-fail-under=80`.
That 20-point gap let coverage silently erode far below the real level while CI
stayed green. Raise the floor to 95% so regressions are caught close to the
actual coverage, while leaving a small margin for genuinely hard-to-cover
defensive code (rather than forcing pragmas).

Chose 95 over 100 deliberately: a hard 100% gate turns every unreachable/
defensive branch into a required `# pragma: no cover`, whereas 95% keeps the
gate strict without that friction.

## Security

None — test configuration only.

## Testing

`make test` — 71 passed, total coverage 100.00%; gate reports "Required test
coverage of 95% reached."