### PR TITLE
docs(coverage): align coverage floor references to 95%

### DIFF
--- a/.claude/skills/ship-changes/SKILL.md
+++ b/.claude/skills/ship-changes/SKILL.md
@@ -71,12 +71,12 @@ git add <paths>   # or: git add -A
 Before committing, mirror what CI enforces so failures are caught locally:
 
 ```bash
-make check       # make lint (ruff + ty) then make test (pytest, coverage ≥ 80%)
+make check       # make lint (ruff + ty) then make test (pytest, coverage ≥ 95%)
 ```
 
 Fix anything that fails before continuing — for lint, prefer
 `uv run ruff check --fix` / `uv run ruff format`; for `ty` errors fix the
-annotations rather than suppressing; for coverage below 80%, add tests under
+annotations rather than suppressing; for coverage below 95%, add tests under
 `tests/`. (`pre-commit` also runs ruff/gitleaks/markdownlint on commit.)
 
 ### 5. Craft the commit message (Conventional Commits)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ please make sure to:
 
 1. Fork the repository and create a new branch for your changes.
 2. Ensure that your code follows the project's coding style and conventions by running `make lint`.
-3. Write tests for your changes; we maintain at least 80% code coverage.
+3. Write tests for your changes; we maintain at least 95% code coverage.
 4. Run `make test` to verify your changes don't break existing functionality.
 5. Write clear and concise commit messages.
 6. Commit messages should follow the [Conventional

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,5 +1,5 @@
 coverage:
-  range: 60..80
+  range: 80..95
   round: down
   precision: 2
   status:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@
   default + dev groups from `uv.lock`). Later targets refresh the environment when
   the lock or `pyproject.toml` changes.
 - Default loop: `make lint` (ruff + ty) → `make test` (pytest,
-  coverage≥80, writes `coverage.xml` + `htmlcov/`) → `make build` (`uv build`).
+  coverage≥95, writes `coverage.xml` + `htmlcov/`) → `make build` (`uv build`).
   `make` runs all three.
 - `make clean` wraps `git clean -xdf`; it nukes `.venv/` and every untracked
   artifact if you need a hard reset.

--- a/.github/prompts/address-pr-feedback.prompt.md
+++ b/.github/prompts/address-pr-feedback.prompt.md
@@ -18,7 +18,7 @@ Address the review feedback on the current pull request for this repository.
    patterns; keep edits scoped to what the comment asks — don't reflow unrelated
    code.
 3. Before committing, run the quality gates with `make check` (`make lint` then
-   `make test`, coverage ≥ 80%). Fix anything that fails.
+   `make test`, coverage ≥ 95%). Fix anything that fails.
 4. Commit the fixes with a Conventional Commits message that references the
    feedback, using **DCO sign-off and GPG signing** (repo policy requires both):
    `git commit -s -S -m "<type>(<scope>): address review feedback"`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,4 @@ are computed or applied? Describe the impact, or write "None". -->
 ## Testing
 
 <!-- How you verified the change. CI already runs lint, type-check, and
-tests (≥80% coverage), so no need to attest to those. -->
+tests (≥95% coverage), so no need to attest to those. -->


### PR DESCRIPTION
## Summary

Align various documentation and configuration references with the newly raised coverage floor of 95% (originally 80%).

Specifically:
- Update ship-changes skill, contributing guidelines, copilot instructions, and address-pr-feedback prompt to state the 95% target.
- Adjust Codecov color range from 60..80 to 80..95.
- Update the PR template to reference the 95% threshold.

## Security

None

## Testing

`make check` - 71 passed, 100% coverage
`prek run --all-files` - all hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution, pull request, and workflow guidance to require at least **95% test coverage** instead of 80%.
  * Aligned quality-check instructions and AI assistant guidance with the higher coverage expectation.
  * Adjusted coverage status settings to reflect the new range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->