### PR TITLE
chore(deps): bump pre-commit hook revisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --indent=4]
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 73c2d77a42a113aee9e4b748c24937f09557b82d  # frozen: 0.11.24
+    rev: 84ed656d5ada0b07830b74fb0fe18b3bc1029441  # frozen: 0.11.26
     hooks:
       - id: uv-lock
         args: [--check]
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: 996abf60411a8d954288ac9856aae7602b80cbda  # frozen: v0.22.1
+    rev: 534166213006ec869b773b7ed8c6ebeaad1165d0  # frozen: v0.23.0
     hooks:
       - id: markdownlint-cli2
   - repo: https://github.com/rhysd/actionlint
@@ -64,7 +64,7 @@ repos:
       # which checks correctness.
       - id: zizmor
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: ea931ccc70c472cfeb2f822acba7f0e12b7842ce  # frozen: 43.243.1
+    rev: 9d4eedeef38d2ec466c87abd58aac963430839fc  # frozen: 43.251.3
     hooks:
       - id: renovate-config-validator
         args: [--strict]


### PR DESCRIPTION
## Summary

Bump pinned `rev` values in `.pre-commit-config.yaml`:

- `astral-sh/uv-pre-commit`: `0.11.24` → `0.11.26`
- `DavidAnson/markdownlint-cli2`: `v0.22.1` → `v0.23.0`
- `renovatebot/pre-commit-hooks`: `43.243.1` → `43.251.3`

## Security

None.

## Testing

`make check` — 71 passed, 100% coverage. `pre-commit` hooks ran clean during
commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several pinned pre-commit hook versions to newer releases.
  * Brought formatting, markdown linting, and automated maintenance hooks up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->