### PR TITLE
ci(coverage): align Codecov thresholds with the 95% floor

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,5 +1,5 @@
 coverage:
-  range: 80..95
+  range: 95..100
   round: down
   precision: 2
   status:
@@ -13,4 +13,4 @@ flag_management:
         target: auto
         threshold: 1%
       - type: patch
-        target: 90%
+        target: 95%


### PR DESCRIPTION
## Summary

Follow-up to raising the coverage floor to 95% (#1339). Two Codecov settings in
`.github/codecov.yaml` still referenced the old posture:

- **`range: 80..95` → `95..100`** — this is the color gradient for the coverage
  graph. With the hard floor at 95% (and the suite at 100%), the 80→95 band was
  unreachable: CI fails before coverage could land there. Retargeting to 95..100
  makes the gradient meaningful.
- **`patch` status `target: 90%` → `95%`** — new code in a PR must now meet the
  same 95% bar as the enforced project floor, instead of a softer 90%.

The `project` status (`target: auto, threshold: 1%`) is left as-is — it's a
relative "don't regress" net, distinct from the absolute floor.

## Security

None — CI/coverage configuration only.

## Testing

Config-only change; no runtime surface. Codecov applies these on the next
coverage upload. Pre-commit hooks passed on commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted code coverage requirements to focus on the highest coverage range and raised the default coverage target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->