### PR TITLE
ci(docker): pull the qemu binfmt image fresh on tag builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -169,6 +169,12 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           image: tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          # Pull the binfmt image fresh on tag builds: the gha image cache is
+          # keyed by repo+tag only and docker-loads the tarball without checking
+          # it against the digest pin above — only a real pull enforces the pin.
+          # Keep the cache for main builds (branch-isolated scope, same trust
+          # argument as the layer cache below).
+          cache-image: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       # Release (tag) builds run cache-free for a hermetic commit→image chain,
       # mirroring the Python workflow. main/PR builds keep the gha cache for


### PR DESCRIPTION
## Description

Gate `setup-qemu-action`'s `cache-image` on non-tag refs, completing the
hermetic-release work from #1336 (buildx layer + binary caches).

This one has the sharpest justification of the three: checking the
implementation in `@docker/actions-toolkit` shows the gha image cache is keyed
by **repo+tag only** and a cache hit goes straight to `docker load` of the
stored tarball — the `@sha256` digest pin on the binfmt image is parsed but
never checked on restore. Only a cache-miss `docker pull` enforces the pin.
Since the binfmt image provides the QEMU emulators that *execute* the arm64
build steps, tag builds now always take the verified pull path.

## Changes Made

- `cache-image: ${{ !startsWith(github.ref, 'refs/tags/') }}` on the
  `Set up QEMU` step, with a comment explaining the digest-bypass rationale.
- main builds keep the cache (branch-isolated scope, same trust argument as the
  layer cache); PR/dependabot builds skip QEMU setup entirely, so nothing
  changes there.
- `reset` deliberately left at its default `false`: GitHub-hosted runners are
  ephemeral with no pre-registered foreign-arch binfmt handlers, so it would be
  a no-op knob.

## Cost

One authenticated ~50 MB Docker Hub pull per release (the step logs in before
QEMU setup, so it counts against the authenticated rate limit).

## Testing

Not runtime-testable locally (CI-only). pre-commit actionlint + zizmor pass.
Behavior change only affects tag builds; the next release exercises it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build workflow behavior so tagged releases use a fresh setup instead of a cached image, while regular branch builds continue using cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->