### PR TITLE
fix(firewall): wait for hcloud actions and handle transport errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ## [v1.3.1] – Unreleased
 
 - Start new development cycle
+- Hardened Hetzner firewall updates: the CLI now waits for each asynchronous
+  `set_rules` action to finish (surfacing action failures and timeouts instead of
+  reporting success at submission), applies a bounded connect/read timeout so a
+  hung API call can no longer stall the run indefinitely, and records transport
+  errors (connection/DNS/TLS failures) as per-firewall failures so the remaining
+  firewalls and projects are still processed
 
 ## [v1.3.0] – 2026-06-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "hcloud>=2.22.0",
     "pydantic>=2.13.4",
     "pyyaml>=6.0.3",
+    "requests>=2.20",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/cf_ips_to_hcloud_fw/firewall.py
+++ b/src/cf_ips_to_hcloud_fw/firewall.py
@@ -6,7 +6,9 @@ import logging
 from typing import TYPE_CHECKING, NamedTuple
 
 from hcloud import APIException, Client
+from hcloud.actions import ActionException
 from hcloud.firewalls.domain import Firewall, FirewallRule
+from requests.exceptions import RequestException
 
 from cf_ips_to_hcloud_fw.custom_logging import log_error
 
@@ -16,6 +18,11 @@ if TYPE_CHECKING:  # pragma: no cover
 CF_IPV4 = "__CLOUDFLARE_IPS_V4__"
 CF_IPV6 = "__CLOUDFLARE_IPS_V6__"
 CF_ALL = "__CLOUDFLARE_IPS__"
+
+# Bounded (connect, read) timeout in seconds. The SDK passes this straight to
+# requests; without it a hung Hetzner API call would stall the whole run
+# indefinitely.
+HCLOUD_TIMEOUT = (5.0, 30.0)
 
 
 class IPVersionTargets(NamedTuple):
@@ -55,14 +62,14 @@ def update_project(
     Returns:
         ProjectOutcome: Labels of skipped and failed firewalls, project-prefixed.
     """
-    client = Client(token=project.token.get_secret_value())
+    client = Client(token=project.token.get_secret_value(), timeout=HCLOUD_TIMEOUT)
     skipped: list[str] = []
     failed: list[str] = []
     for name in project.firewalls:
         label = f"project {project_index}:{name!r}"
         try:
             fw = client.firewalls.get_by_name(name)
-        except APIException as e:
+        except (APIException, RequestException) as e:
             log_error(
                 "hcloud/firewalls.get_by_name failed for "
                 f"{name!r} in project {project_index}: {e}"
@@ -151,21 +158,27 @@ def update_firewall_rule(
 def fw_set_rules(client: Client, fw: Firewall, project_index: int) -> bool:
     """Persist rule updates to Hetzner via the SDK.
 
+    set_rules is asynchronous: the SDK returns one action per request and each
+    only reflects the final result once finished. We wait on every action so a
+    later failure or timeout is surfaced instead of being reported as success.
+
     Args:
         client: Authenticated Hetzner Cloud client.
         fw: Firewall whose rules were modified earlier in the flow.
         project_index: 1-based index of the project being processed, used for logging.
 
     Returns:
-        bool: True on success, False when the API call failed.
+        bool: True on success, False when the API call or an action failed.
     """
     logging.info(
         f"Updating rules for hcloud firewall {fw.name!r} in project {project_index}"
     )
     try:
         rules = fw.rules or []
-        client.firewalls.set_rules(fw, rules)
-    except APIException as e:
+        actions = client.firewalls.set_rules(fw, rules)
+        for action in actions:
+            action.wait_until_finished()
+    except (APIException, ActionException, RequestException) as e:
         log_error(
             f"hcloud/firewall.set_rules failed for {fw.name!r} in project "
             f"{project_index}: {e}"

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -6,8 +6,10 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 from hcloud import APIException
+from hcloud.actions import ActionFailedException, ActionTimeoutException
 from hcloud.firewalls.domain import Firewall, FirewallRule
 from pydantic import SecretStr
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from cf_ips_to_hcloud_fw.firewall import (
     CF_ALL,
@@ -270,11 +272,15 @@ def test_update_firewall_already_up_to_date(
 )
 @patch("cf_ips_to_hcloud_fw.firewall.Client")
 def test_fw_set_rules(mock_client: MagicMock, *, rules: list[FirewallRule]) -> None:
-    """fw_set_rules forwards the current rule list to the SDK verbatim."""
+    """fw_set_rules forwards the rules and waits for every returned action."""
     expected = rules or []
     fw = Firewall(name="fw-1", rules=rules)
+    action1, action2 = MagicMock(), MagicMock()
+    mock_client.firewalls.set_rules.return_value = [action1, action2]
     assert fw_set_rules(mock_client, fw, 1) is True
     mock_client.firewalls.set_rules.assert_called_once_with(fw, expected)
+    action1.wait_until_finished.assert_called_once_with()
+    action2.wait_until_finished.assert_called_once_with()
 
 
 @patch("cf_ips_to_hcloud_fw.firewall.Client")
@@ -290,6 +296,46 @@ def test_fw_set_rules_fail(mock_logging: MagicMock, mock_client: MagicMock) -> N
     mock_logging.assert_called_once_with(
         "hcloud/firewall.set_rules failed for 'fw-1' in project 1: "
         "Message (Test exception)"
+    )
+
+
+@pytest.mark.parametrize(
+    "exc_cls",
+    [ActionFailedException, ActionTimeoutException],
+)
+@patch("cf_ips_to_hcloud_fw.firewall.Client")
+@patch("logging.error")
+def test_fw_set_rules_action_fail(
+    mock_logging: MagicMock,
+    mock_client: MagicMock,
+    exc_cls: type[ActionFailedException | ActionTimeoutException],
+) -> None:
+    """An action that fails or times out while waiting reports failure."""
+    fw = Firewall(name="fw-1", rules=[])
+    failed_action = MagicMock(error=None, command="set_rules", id=42)
+    action = MagicMock()
+    action.wait_until_finished.side_effect = exc_cls(action=failed_action)
+    mock_client.firewalls.set_rules.return_value = [action]
+    assert fw_set_rules(mock_client, fw, 1) is False
+    action.wait_until_finished.assert_called_once_with()
+    mock_logging.assert_called_once()
+    assert mock_logging.call_args.args[0].startswith(
+        "hcloud/firewall.set_rules failed for 'fw-1' in project 1: "
+    )
+
+
+@patch("cf_ips_to_hcloud_fw.firewall.Client")
+@patch("logging.error")
+def test_fw_set_rules_transport_fail(
+    mock_logging: MagicMock, mock_client: MagicMock
+) -> None:
+    """A transport error (e.g. connection failure) reports failure, not a crash."""
+    fw = Firewall(name="fw-1", rules=[])
+    mock_client.firewalls.set_rules.side_effect = RequestsConnectionError("boom")
+    assert fw_set_rules(mock_client, fw, 1) is False
+    mock_client.firewalls.set_rules.assert_called_once_with(fw, [])
+    mock_logging.assert_called_once_with(
+        "hcloud/firewall.set_rules failed for 'fw-1' in project 1: boom"
     )
 
 
@@ -321,6 +367,9 @@ def test_update_project_found(
     project = Project(token=SecretStr("token-1"), firewalls=["fw-1"])
     outcome = update_project(project=project, cf_cidrs=cf_ips, project_index=1)
     assert outcome == ([], [])
+    # A bounded timeout is passed so a hung API call cannot stall the run.
+    _, kwargs = mock_client.call_args
+    assert kwargs["timeout"] == (5.0, 30.0)
     mock_client.return_value.firewalls.get_by_name.assert_called_once_with("fw-1")
     mock_update_firewall.assert_called_once_with(
         mock_client.return_value, fw, cf_ips, project_index=1
@@ -407,6 +456,39 @@ def test_update_project_fail_continues(
     mock_logging.assert_called_once_with(
         "hcloud/firewalls.get_by_name failed for 'fw-1' in project 1: "
         "Message (Test exception)"
+    )
+
+
+@patch("cf_ips_to_hcloud_fw.firewall.Client")
+@patch("cf_ips_to_hcloud_fw.firewall.update_firewall", return_value=True)
+@patch("logging.error")
+def test_update_project_transport_fail_continues(
+    mock_logging: MagicMock,
+    mock_update_firewall: MagicMock,
+    mock_client: MagicMock,
+) -> None:
+    """A transport error on get_by_name is recorded and the next firewall runs."""
+    fw2 = Firewall(2, "fw-2")
+    # fw-1 fails at the transport layer (no APIException); fw-2 must still sync.
+    mock_client.return_value.firewalls.get_by_name.side_effect = [
+        RequestsConnectionError("boom"),
+        fw2,
+    ]
+    project = Project(token=SecretStr("token-1"), firewalls=["fw-1", "fw-2"])
+    cf_ips = CloudflareCIDRs(ipv4_cidrs=["127.1/32"], ipv6_cidrs=["::1/64"])
+
+    outcome = update_project(project=project, cf_cidrs=cf_ips, project_index=1)
+
+    assert outcome == ([], ["project 1:'fw-1'"])
+    mock_client.return_value.firewalls.get_by_name.assert_has_calls([
+        call("fw-1"),
+        call("fw-2"),
+    ])
+    mock_update_firewall.assert_called_once_with(
+        mock_client.return_value, fw2, cf_ips, project_index=1
+    )
+    mock_logging.assert_called_once_with(
+        "hcloud/firewalls.get_by_name failed for 'fw-1' in project 1: boom"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,6 +43,7 @@ dependencies = [
     { name = "hcloud" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "requests" },
 ]
 
 [package.dev-dependencies]
@@ -58,6 +59,7 @@ requires-dist = [
     { name = "hcloud", specifier = ">=2.22.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "requests", specifier = ">=2.20" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Two robustness fixes to the Hetzner firewall update path:

- **Wait for asynchronous actions.** `set_rules` returns one `BoundAction` per
  request that only reflects its final result once finished. `fw_set_rules` now
  calls `wait_until_finished()` on every returned action, so an action that
  later fails or times out is surfaced as a failure instead of being reported
  as success at submission time.
- **Bounded timeout.** The hcloud `Client` is constructed with a `(5s, 30s)`
  connect/read timeout so a hung API call can no longer stall the whole run
  indefinitely (the SDK previously passed `timeout=None` to `requests`).
- **Transport-error handling.** Both API call sites now catch
  `requests.RequestException` alongside `APIException`. Connection/DNS/TLS
  failures escape the SDK as `requests` exceptions (only `Timeout` and
  `APIException` are retried internally); they are now recorded as per-firewall
  failures so the remaining firewalls and projects are still processed,
  extending the existing continue-on-failure behaviour.

`requests` is added as an explicit dependency since its exception type is now
imported directly rather than relied on transitively via hcloud.

## Security

None. No changes to token handling or firewall-rule content; waiting on actions
means a genuinely failed rule push now exits non-zero instead of silently
reporting success.

## Testing

`make check` — 75 passed, 100% coverage. New tests cover action waiting on
success, action failure and timeout, transport errors on both `set_rules` and
`get_by_name` (with continuation), and the client timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Firewall rule updates now wait for asynchronous actions to complete before reporting success.
  - Action failures, timeouts, and connection errors are surfaced clearly.
  - Network operations use bounded timeouts to prevent indefinite hangs.
  - A failed firewall update no longer prevents remaining firewalls or projects from processing.

- **Documentation**
  - Updated the changelog with the improved firewall update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->