### PR TITLE
ci: verify release tag matches project version before publishing

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -90,6 +90,34 @@ jobs:
         with:
           persist-credentials: false
 
+      # Fail closed when a release tag doesn't match the project version, so a
+      # mistaken tag can't publish images whose semver tags (derived from the
+      # git tag) disagree with the packaged version, or ship a non-final
+      # (.dev/pre-release/local) version. Only meaningful on tag pushes; runs
+      # first so a bad tag stops the build before any registry work.
+      - name: Verify tag matches project version
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(sed -nE 's/^version = "([^"]+)"$/\1/p' pyproject.toml)"
+          if [ -z "$version" ]; then
+            echo "::error::Could not read version from pyproject.toml"
+            exit 1
+          fi
+          expected="${TAG#v}"
+          if [ "$version" != "$expected" ]; then
+            echo "::error::Tag $TAG (version '$expected') does not match pyproject.toml version '$version'"
+            exit 1
+          fi
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Refusing to publish non-final version '$version' from tag $TAG"
+            exit 1
+          fi
+          echo "Release version '$version' matches tag $TAG"
+
       # Verify the uv base images carry astral-sh's signed SLSA build provenance
       # before building on them — fail closed, so a PR that repins to an
       # unattested or tampered digest stops the build. Runs before the QEMU/

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -248,12 +248,62 @@ jobs:
           flags: python-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  check-release-version:
+    name: Check release version
+    # Only tag pushes publish; guard them so a mistaken tag can't ship a version
+    # that disagrees with pyproject.toml or a non-final (.dev/pre-release/local)
+    # version. Gating the publish chain on this job (see needs below) fails the
+    # whole release before anything reaches PyPI, which is irreversible.
+    if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Verify tag matches project version
+        env:
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(sed -nE 's/^version = "([^"]+)"$/\1/p' pyproject.toml)"
+          if [ -z "$version" ]; then
+            echo "::error::Could not read version from pyproject.toml"
+            exit 1
+          fi
+          expected="${TAG#v}"
+          if [ "$version" != "$expected" ]; then
+            echo "::error::Tag $TAG (version '$expected') does not match pyproject.toml version '$version'"
+            exit 1
+          fi
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Refusing to publish non-final version '$version' from tag $TAG"
+            exit 1
+          fi
+          echo "Release version '$version' matches tag $TAG"
+
   provenance-and-draft-release:
     name: Generate provenance and create draft release
     if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - build
       - upload-event-file
+      - check-release-version
     permissions:
       actions: read
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   hung API call can no longer stall the run indefinitely, and records transport
   errors (connection/DNS/TLS failures) as per-firewall failures so the remaining
   firewalls and projects are still processed
+- Guarded the release workflows against mistaken tags: a `v*` tag now fails the
+  Python and Docker publish pipelines unless the tag matches the `pyproject.toml`
+  version exactly and that version is a final `X.Y.Z` release (no `.dev`,
+  pre-release, or local component), preventing a wrong or non-final version from
+  reaching PyPI or producing mismatched Docker semver tags
 
 ## [v1.3.0] – 2026-06-14
 


### PR DESCRIPTION
## Summary

A pushed `v*` tag previously entered the publish path with no check that it
agreed with the `pyproject.toml` version or that the version was a final
release. A mistaken tag could publish the wrong (or a `.dev`) version to PyPI —
which is irreversible — and produce mismatched Docker semver tags.

Add a fail-closed guard to both release workflows:

- **`python-package.yaml`**: a tag-only `check-release-version` job that the
  publish chain (`provenance-and-draft-release` → TestPyPI → PyPI → GitHub
  release) now depends on, so nothing reaches the irreversible PyPI upload on a
  bad tag.
- **`docker.yaml`**: a fail-fast step in the `docker` job (the sole publisher;
  the three provenance jobs `needs: docker`) that stops a bad tag before any
  registry work.

The guard requires `${TAG#v}` to exactly equal the `pyproject.toml` version and
that version to be a final `X.Y.Z` release, rejecting mismatches and
`.dev`/pre-release/local versions.

## Security

Hardens the release supply chain: prevents an accidental or malformed `v*` tag
from publishing a wrong/non-final version to PyPI or mislabelled Docker images.
Guard input (`github.ref_name`) is passed via `env:` and referenced as `$TAG`,
not interpolated into the shell.

Complementary manual follow-up (cannot be encoded in a workflow): add a GitHub
tag ruleset restricting who can create `v*` tags — the guard fails an
already-created bad tag; a ruleset limits tag creation in the first place.

## Testing

Guard script tested locally against 7 cases (matching final, dev/release
mismatch, dev tag, `rc` pre-release, prefix collision `v1.3.1` vs `1.3.10`,
local segment, second final) — all correct. `actionlint`, `zizmor`, and
`markdownlint` pass; `make check` — 75 passed, 100% coverage.