### PR TITLE
docs(ci): correct multi-arch build note in docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -162,8 +162,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # QEMU/binfmt only emulates non-host architectures; skip it (and its Docker
-      # Hub pull) unless we actually build multi-arch — PR/branch/bot builds are
-      # single-arch amd64.
+      # Hub pull) unless we actually build multi-arch. Only PR and Dependabot
+      # builds are single-arch amd64; main and tag pushes build (and publish)
+      # amd64+arm64, matching the platforms expression on the build step below.
       - name: Set up QEMU
         if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0


### PR DESCRIPTION
## Summary

The QEMU-setup comment in `docker.yaml` claimed *PR/branch/bot* builds are
single-arch amd64. But the QEMU `if` and the build step's `platforms` expression
share the same `github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'`
condition, so **main and tag pushes build and publish `amd64+arm64`**; only
**PR and Dependabot** builds are single-arch amd64.

Multi-arch on `main` is intended (the project ships `linux/amd64 + arm64` and
`:main` is a published rolling tag), so this corrects the comment to match the
behavior — no workflow behavior change.

## Security

None. Comment-only change.

## Testing

Comment-only; no runtime surface. `actionlint`, `zizmor`, and the other
pre-commit hooks pass.