### PR TITLE
ci(trufflehog): allow api.lob.com so secret verification can run

### DIFF
--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -29,8 +29,14 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: block
+          # api.lob.com is TruffleHog's Lob-detector verification endpoint: a
+          # candidate in the scanned history trips that detector, and with
+          # verification enabled TruffleHog dials Lob to confirm it. Allow the
+          # host so verification actually runs (returns a definite verified/not
+          # result) instead of a blocked DNS lookup tripping harden-runner.
           allowed-endpoints: >
             api.github.com:443
+            api.lob.com:443
             ghcr.io:443
             github.com:443
             pkg-containers.githubusercontent.com:443


### PR DESCRIPTION
## Summary

The **StepSecurity Harden-Runner** check has been failing repo-wide (on open
PRs) because of the TruffleHog secret scan. A candidate in the scanned git
history trips TruffleHog's **Lob** detector, and with verification enabled
(`--results=verified,unknown`) TruffleHog dials `api.lob.com` to confirm it. The
`egress-policy: block` harden-runner drops that DNS lookup
(`matchedPolicy=NONE`), which fails the aggregate harden-runner check — even
though the `Secret scan` job itself exits clean.

Allow `api.lob.com:443` in the TruffleHog job's egress allowlist (matching the
existing "add endpoint from harden-runner insights" pattern) so verification
actually runs and returns a definite verified/not-verified result instead of a
blocked lookup being flagged. The justification is a YAML comment *above* the
folded `allowed-endpoints` scalar — an inline `#` would be parsed as part of an
endpoint string.

## Security

Widens egress for the secret-scan job by a single host that TruffleHog
legitimately needs for Lob verification. `verified_secrets: 0` in the failing
run reflected a *blocked* lookup, not a confirmed-fake credential, so this also
lets the scan definitively verify the candidate — this project does not use Lob,
so it is expected to come back not-verified; if it verifies as live, that is a
real finding to rotate.

## Testing

`actionlint`, `zizmor`, and gitleaks pass. Parsed the folded scalar to confirm
the value is exactly the five intended endpoints with no comment leakage.