### PR TITLE
ci(pr-title): rerun check on new pushes to the PR

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -10,7 +10,7 @@ name: PR title
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The PR title workflow only triggered on `opened`, `edited`, and `reopened`
events. When new commits were pushed to a PR (`synchronize` event), the
check did not rerun, causing the required status check to hang
indefinitely waiting for a result that would never arrive.

Adds `synchronize` to the event types so the title check reruns on every
push.

Fixes #1355 (unblocks the stuck status check).

## Security

None.

## Testing

`make check` — 75 passed, 100% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull request title validation now runs when new commits are pushed to an existing pull request.
  * Validation continues to run when pull requests are opened, edited, or reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->