### PR TITLE
build(docker): source uv base image from Docker Hub so Renovate can group it

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -139,7 +139,8 @@
             "matchPackageNames": [
                 "astral-sh/uv",
                 "astral-sh/uv-pre-commit",
-                "ghcr.io/astral-sh/uv"
+                "astral/uv",
+                "docker.io/astral/uv"
             ]
         },
         {
@@ -148,7 +149,8 @@
             "matchPackageNames": [
                 "astral-sh/uv",
                 "astral-sh/uv-pre-commit",
-                "ghcr.io/astral-sh/uv"
+                "astral/uv",
+                "docker.io/astral/uv"
             ],
             "matchUpdateTypes": [
                 "major"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -118,10 +118,22 @@ jobs:
           fi
           echo "Release version '$version' matches tag $TAG"
 
+      # Log in to Docker Hub before the provenance check and the QEMU/buildx
+      # tooling pulls so every Docker Hub request — including the uv base-image
+      # manifest fetches in the verify step below — counts against the
+      # authenticated limit, not the shared-runner anonymous pool. Skipped for
+      # fork PRs and Dependabot (no secret access); those fall back to anonymous.
+      - name: Login to DockerHub
+        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]' }}
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Verify the uv base images carry astral-sh's signed SLSA build provenance
       # before building on them — fail closed, so a PR that repins to an
       # unattested or tampered digest stops the build. Runs before the QEMU/
-      # buildx/login setup to fail fast. Only the uv images are checkable here:
+      # buildx setup to fail fast. Only the uv images are checkable here:
       # the python base is a Docker Official Image whose inline provenance is
       # unsigned (no verifiable signer). Refs are read from the Dockerfile so the
       # pins stay single-sourced; the found guard trips if the pin format drifts
@@ -140,7 +152,7 @@ jobs:
               --owner astral-sh \
               --predicate-type https://slsa.dev/provenance/v1
             echo "::endgroup::"
-          done < <(grep -oE 'ghcr\.io/astral-sh/uv:[^ @]+@sha256:[0-9a-f]{64}' Dockerfile | sort -u)
+          done < <(grep -oE 'docker\.io/astral/uv:[^ @]+@sha256:[0-9a-f]{64}' Dockerfile | sort -u)
           if [ "$found" -eq 0 ]; then
             echo "::error::No uv base images found in Dockerfile — verification would be a no-op"
             exit 1
@@ -162,16 +174,6 @@ jobs:
             type=semver,pattern={{major}}
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && ',index' || '' }}
-
-      # Log in before pulling the QEMU/buildx tooling images so those Docker Hub
-      # pulls count against the authenticated limit, not the shared-runner
-      # anonymous pool.
-      - name: Login to DockerHub
-        if: ${{ (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]' }}
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to Quay
         if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.25.0@sha256:0adf442eae370b6087e08edc7c50b552d80ddf261576f4ebd6421006b2461f12
 # check=experimental=all;error=true
 
-FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.11.26-python3.14-trixie@sha256:fc2acf3556b55b4474fef2d41d267f8f819c8c393fe20ea35e764e2282427de4 AS uv-tools-trixie
-FROM ghcr.io/astral-sh/uv:0.11.26-python3.14-alpine3.23@sha256:e852e37cfaffb287f2d78de0d4f27e28bf0722ccbf0d6948dbdf19a0b4de7bc7 AS uv-tools-alpine
+FROM --platform=$BUILDPLATFORM docker.io/astral/uv:0.11.26-python3.14-trixie@sha256:fc2acf3556b55b4474fef2d41d267f8f819c8c393fe20ea35e764e2282427de4 AS uv-tools-trixie
+FROM docker.io/astral/uv:0.11.26-python3.14-alpine3.23@sha256:e852e37cfaffb287f2d78de0d4f27e28bf0722ccbf0d6948dbdf19a0b4de7bc7 AS uv-tools-alpine
 
 FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/python:3.14.6-trixie@sha256:7a320a6d1216cd356eb4790261f2332e6e29e32f7e80646cb3e79f9e65b8e2c2 AS builder
 


### PR DESCRIPTION
## Summary

Switch the uv build-stage base from `ghcr.io/astral-sh/uv` to
`docker.io/astral/uv` so Renovate can group its updates with the other uv
artifacts.

**Why:** Renovate can't read a release timestamp from GitHub Container Registry
(upstream astral/uv issue #39064). With this repo's `minimumReleaseAge: "3 days"`
+ `internalChecksFilter: "strict"`, the uv image never cleared the stability
gate and kept shipping as a separate trailing PR instead of bundling with
`astral-sh/uv` (setup-uv) and `astral-sh/uv-pre-commit`. Docker Hub's tags API
exposes `tag_last_pushed`, so the gate works there and the image rejoins the
`uv` package group.

**What changed:**
- `Dockerfile` — both uv stages now pull `docker.io/astral/uv`. astral mirrors
  byte-identical manifests, so the pinned **tags and digests are unchanged**.
- `docker.yaml` — provenance-verify grep re-anchored to `docker.io/astral/uv`;
  the Docker Hub login moves above the verify step so its base-image manifest
  fetches count against the authenticated pull limit, not the anonymous pool.
- `renovate.json` — the two `uv` rules match both `astral/uv` and
  `docker.io/astral/uv`, so grouping holds regardless of how Renovate
  normalizes the name.

Bundling won't be visible on the next Renovate run (setup-uv and uv-pre-commit
already merged at 0.11.28 in #1360); confirmation is the image dropping out of
the dashboard's pending state, or the next uv release grouping all three.

## Security

Provenance gate preserved. The fail-closed `gh attestation verify --owner
astral-sh` step still verifies the uv base: astral's SLSA attestation is keyed
by digest+owner, and the Docker Hub digest is byte-identical to the attested
`ghcr.io/astral-sh/uv` digest (verified: `gh attestation verify
oci://docker.io/astral/uv:0.11.26-python3.14-trixie --owner astral-sh` passes).
No token, secret, or firewall-rule changes.

One new exposure: the verify step's Docker Hub manifest fetches are anonymous on
fork-PR and Dependabot runs (login is secret-gated off there) — a possible
`toomanyrequests` flake that didn't exist on GHCR.

## Testing

`make check` — ruff + ty clean, 75 passed, 100% coverage. pre-commit passed,
including `actionlint`, `zizmor`, and `renovate-config-validator`. Docker Hub
digest identity and the `astral-sh` attestation on the Docker Hub image verified
out-of-band with `gh attestation verify`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `uv` container image references to use Docker Hub.
  * Improved authenticated image verification during Docker builds.
  * Preserved existing `uv` versions and build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->