### PR TITLE
chore(lint): remove superfluous ruff ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,23 +129,10 @@ extend-select = [
 ]
 ignore = [
     "missing-trailing-comma",
-    "prohibited-trailing-comma",
-    "indentation-with-invalid-multiple",
-    "indentation-with-invalid-multiple-comment",
-    "over-indented",
     "incorrect-blank-line-before-class",
-    "docstring-tab-indentation",
     "multi-line-summary-second-line",
-    "triple-single-quotes",
     "missing-blank-line-after-last-section",
     "root-logger-call",
-    "bad-quotes-inline-string",
-    "bad-quotes-multiline-string",
-    "bad-quotes-docstring",
-    "avoidable-escaped-quote",
-    "single-line-implicit-string-concatenation",
-    "multi-line-implicit-string-concatenation",
-    "tab-indentation",
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
## Summary

Removed 13 ruff preview ignores from `pyproject.toml` that never fire on the
codebase. Only 5 ignores are actually needed:

- `missing-trailing-comma` — project style (66 violations)
- `missing-blank-line-after-last-section` — docstring style (16 violations)
- `root-logger-call` — intentional root logger use (12 violations)
- `incorrect-blank-line-before-class` — incompatible pair with `D211`
- `multi-line-summary-second-line` — incompatible pair with `D212`

The dropped ignores (`prohibited-trailing-comma`,
`indentation-with-invalid-multiple`,
`indentation-with-invalid-multiple-comment`, `over-indented`,
`docstring-tab-indentation`, `triple-single-quotes`,
`bad-quotes-inline-string`, `bad-quotes-multiline-string`,
`bad-quotes-docstring`, `avoidable-escaped-quote`,
`single-line-implicit-string-concatenation`,
`multi-line-implicit-string-concatenation`, `tab-indentation`) produced zero
violations when re-enabled.

## Security

None

## Testing

`make check` — 75 passed, 100% coverage