### PR TITLE
chore(skills): run ship-changes on sonnet

### DIFF
--- a/.claude/skills/ship-changes/SKILL.md
+++ b/.claude/skills/ship-changes/SKILL.md
@@ -2,6 +2,7 @@
 name: ship-changes
 description: 'Ship the current working-tree changes as a pull request. Use when asked to commit and push, open a PR, ship/submit changes, create a feature branch and PR, or "make a PR for this". Creates a feature branch if on the default branch, crafts a Conventional Commits message, commits with DCO sign-off and GPG signing, pushes, and opens a GitHub PR with a Conventional Commits title.'
 argument-hint: 'Optional: PR type/scope, target branch, or extra context for the commit/PR'
+model: sonnet
 ---
 
 # Ship Changes as a Pull Request


### PR DESCRIPTION
## Summary
Adds a `model: sonnet` frontmatter override to the `ship-changes` skill so the mechanical commit/push/PR workflow runs on Sonnet instead of the session's Opus. The override applies only for the turn that invokes `/ship-changes` and reverts to the session model afterward.

`model` is a Claude Code extension to the [Agent Skills](https://agentskills.io) standard (the spec defines `name`/`description`/`license`/`compatibility`/`metadata`/`allowed-tools`). Other consumers of `.claude/skills` — e.g. Antigravity via `.agents/skills.json` — ignore the unrecognized top-level key, and its value (`sonnet`) is a Claude model name that wouldn't map to their models anyway, so this is a no-op for them.

## Security
None — skill config only; no code, tokens, or firewall rules touched.

## Testing
`make check` — 75 passed, 100% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the change-shipping skill configuration to use the Sonnet model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->