### PR TITLE
ci: scan locked deps for malware and add make audit target

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -61,6 +61,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            api.osv.dev:443
             files.pythonhosted.org:443
             github.com:443
             objects.githubusercontent.com:443
@@ -83,8 +84,13 @@ jobs:
           # by a poisoned cache (cache-poisoning audit).
           enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
+      # Scan the locked deps against OSV's malware advisories on every PR/push
+      # sync. Kept off the hermetic release path (build-dist) on purpose so a
+      # publish never depends on OSV availability.
       - name: Sync dependencies
-        run: uv sync --group dev --frozen
+        env:
+          UV_MALWARE_CHECK: "1"
+        run: uv sync --group dev --frozen --preview-features malware-check
 
       - name: Lint (ruff)
         run: uv run --no-sync ruff check --output-format=github

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,11 @@ UV_RUN_FLAGS := --no-sync   # env is already synced via $(SYNC_STAMP); don't re-
 .PHONY: all
 all: lint test build
 
+# UV_MALWARE_CHECK scans the locked deps against OSV's malware advisories on
+# sync; override with UV_MALWARE_CHECK=0 to sync offline. Kept out of the
+# release path in CI (build-dist stays hermetic) — see python-package.yaml.
 $(SYNC_STAMP): pyproject.toml uv.lock
-	$(UV) sync $(UV_SYNC_FLAGS)
+	UV_MALWARE_CHECK=$${UV_MALWARE_CHECK:-1} $(UV) sync $(UV_SYNC_FLAGS) --preview-features malware-check
 	touch $(SYNC_STAMP)
 
 .PHONY: venv
@@ -34,6 +37,10 @@ lint: $(SYNC_STAMP)
 .PHONY: test
 test: $(SYNC_STAMP)
 	$(UV) run $(UV_RUN_FLAGS) pytest
+
+.PHONY: audit
+audit:
+	$(UV) audit --preview-features audit-command --frozen
 
 .PHONY: check
 check: lint test


### PR DESCRIPTION
## Summary

Add supply-chain scanning around dependency syncs.

- Enable uv's OSV malware check (`UV_MALWARE_CHECK=1`, `--preview-features
  malware-check`) on the `test` job's sync step and on local `make sync`, so
  locked deps are checked against OSV's malware advisories on every sync.
- Add `api.osv.dev:443` to the `test` job's harden-runner egress allowlist.
- Keep the malware check **off** the hermetic release path (`build-dist`,
  `package-check`) so a publish never depends on OSV availability. The Makefile
  sync honours `UV_MALWARE_CHECK=0` as an offline opt-out.
- Add a `make audit` target (`uv audit --preview-features audit-command
  --frozen`) for on-demand local auditing. Deliberately kept out of `all`/CI:
  Renovate's `osvVulnerabilityAlerts` already scans the unchanged lockfile
  against OSV continuously, and `uv audit` is still experimental.

Both uv features are preview in the pinned uv 0.11.29 and may change with a uv
bump.

## Security

No token/secret or firewall-rule changes. Adds an outbound egress allowance to
`api.osv.dev` in the `test` job only; the release/publish jobs are untouched and
remain independent of OSV.

## Testing

- `make check` — 75 passed, 100% coverage.
- `make audit` — clean (no known vulnerabilities / adverse statuses).
- `make sync` after cache bust — runs the malware check ("Checked 31 packages");
  `UV_MALWARE_CHECK=0` opt-out verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `audit` command to scan project dependencies for malware advisories.
  * Dependency synchronization now performs malware-advisory checks by default, with an option to disable them.

* **Chores**
  * Automated dependency checks now have the required network access to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->