### PR TITLE
ci(deps): reinstate uv dependency submission workflow

### DIFF
--- a/.github/workflows/uv-dependency-submission.yaml
+++ b/.github/workflows/uv-dependency-submission.yaml
@@ -1,0 +1,41 @@
+# Until GitHub's automatic dependency submission supports uv.lock, keep this workflow active
+name: uv dependency submission
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/uv.lock"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-submission:
+    name: Submit uv dependencies
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write # needs to submit dependency graph data
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Submit dependency snapshot
+        uses: rmuir/uv-dependency-submission@8c650a3e5e519b93e604e644f7a4a3953144babe # v1.1.1


### PR DESCRIPTION
## Summary

GitHub still does not natively parse `uv.lock` for the dependency graph, so the
`network/dependencies` view had frozen at a ~1-month-old snapshot after
`rmuir/uv-dependency-submission` was removed in #1312.

Verified on 2026-07-17:
- GitHub's dependency-graph supported-ecosystems docs list `requirements.txt`,
  `pipfile.lock`, `poetry.lock`, `pipfile`, and `setup.py` for Python — **not**
  `uv.lock`.
- The repo's GraphQL `dependencyGraphManifests` reports **0 deps** for both
  `uv.lock` and `pyproject.toml`; the Python packages still shown were the
  leftover snapshot from the last workflow run (~June 20), stale ever since.

This restores the workflow (which submits the uv-resolved snapshot, transitive
deps included) and bumps `step-security/harden-runner` to v2.20.0 to match the
rest of the repo. `rmuir/uv-dependency-submission` stays at v1.1.1 (current
latest) and `actions/checkout` at v7.0.0 (already current).

Effectively reverts #1312.

## Security

None. Workflow-only change. Job scope is unchanged from the prior version:
top-level `permissions: {}` with `contents: write` only on the submission job,
hardened runner with blocked egress allowing just `api.github.com` and
`github.com`, and `persist-credentials: false` on checkout. All third-party
actions remain SHA-pinned.

## Testing

`make check` — 75 passed, 100% coverage. pre-commit (actionlint + zizmor
workflow linting) passed on commit.