### PR TITLE
docs(readme): document Hetzner API token blast radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,10 @@ limit exposure operationally instead:
 - **Prefer environment variables over a config file.** Passing the token via
   `HCLOUD_TOKEN` (see [Using Environment
   Variables](#using-environment-variables-single-project)) keeps it out of any
-  on-disk file and lets your platform inject it as a native Docker or Kubernetes
-  secret. Use `config.yaml` when you need to drive several projects in one run.
+  on-disk file, and lets Kubernetes inject it straight from a Secret with
+  `secretKeyRef`. Docker Swarm secrets are mounted as files and never exported
+  into the environment — mount one as `config.yaml` instead. Use `config.yaml`
+  as well when you need to drive several projects in one run.
 - **Restrict the config file when you do use one.** See the permission notes in
   [Configuring the Application](#configuring-the-application).
 - **Rotate the token periodically**, and revoke it immediately if a host that

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ rules up-to-date with the current Cloudflare IP ranges.
   - [Docker and Kubernetes](#docker-and-kubernetes)
 - [Configuration](#configuration)
   - [Preparing the Hetzner Cloud Firewall](#preparing-the-hetzner-cloud-firewall)
+  - [Securing the API Token](#securing-the-api-token)
   - [Configuring the Application](#configuring-the-application)
   - [Using Environment Variables (Single Project)](#using-environment-variables-single-project)
 - [Usage](#usage)
@@ -276,7 +277,37 @@ To prepare your Hetzner Cloud Firewall:
    for the project that contains the firewall. This token will be used to
    authenticate your requests to the Hetzner Cloud API. You can generate a token
    in the Hetzner Cloud Console by going to "Security" > "API Tokens" >
-   "Generate API Token".
+   "Generate API Token". Read [Securing the API
+   Token](#securing-the-api-token) before you do — the token is more powerful
+   than this tool needs.
+
+### Securing the API Token
+
+Hetzner Cloud API tokens are **project-wide and read-write**. There is no
+firewall-only scope: the same token this tool uses to edit firewall rules can
+also create and delete servers, volumes, snapshots, and every other resource in
+that project.
+
+This tool only ever reads firewalls and writes their rules, but the Hetzner API
+cannot enforce that restriction for you. Nor does moving the firewalls to a
+separate project help — a firewall must live in the same project as the servers
+it protects. So treat the token as equivalent to full control of the project and
+limit exposure operationally instead:
+
+- **Prefer environment variables over a config file.** Passing the token via
+  `HCLOUD_TOKEN` (see [Using Environment
+  Variables](#using-environment-variables-single-project)) keeps it out of any
+  on-disk file and lets your platform inject it as a native Docker or Kubernetes
+  secret. Use `config.yaml` when you need to drive several projects in one run.
+- **Restrict the config file when you do use one.** See the permission notes in
+  [Configuring the Application](#configuring-the-application).
+- **Rotate the token periodically**, and revoke it immediately if a host that
+  held it is decommissioned or compromised. Hetzner tokens cannot be rotated in
+  place: generate a replacement under "Security" > "API Tokens", roll it out,
+  then delete the old one. The tool picks up the new value on its next run, with
+  no other changes needed.
+- **Use a separate token per deployment** rather than sharing one across hosts,
+  so a single revocation doesn't take down everything else.
 
 ### Configuring the Application
 


### PR DESCRIPTION
## Summary

The README asked for a Hetzner API token with "write permissions" without
saying what that actually grants. Hetzner Cloud tokens are project-wide and
read-write with no firewall-only scope, so the token this tool needs can also
create and delete servers, volumes, snapshots, and every other resource in the
same project.

Least privilege isn't reachable here: the Hetzner API has no finer scope, and
isolating the firewalls in a dedicated project doesn't work because a firewall
must live alongside the servers it protects. So this documents the blast radius
and gives the guidance that does help — prefer `HCLOUD_TOKEN` injection over an
on-disk config file, restrict the file when one is used, rotate tokens, and use
a separate token per deployment.

Adds a `### Securing the API Token` section under Configuration, a
forward-pointer from the "Generate an API token" step, and the matching
(manually maintained) TOC entry.

## Security

Documentation only — no change to how tokens are handled or how firewall rules
are computed or applied. The intent is to correct an understatement of the
token's privilege in the setup instructions.

## Testing

`make check` — 75 passed, 100% coverage. markdownlint passes. Verified every
in-page anchor resolves (including the two new cross-links) and no prose line
exceeds the repo's 100-char guideline. Cross-checked the "only ever reads
firewalls and writes their rules" claim against `firewall.py`, which calls
`firewalls.get_by_name` and `firewalls.set_rules` and nothing else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Securing the API Token” section to the documentation.
  * Added guidance on protecting API tokens, including environment variables, file permissions, token rotation, revocation, and using separate tokens per deployment.
  * Updated the table of contents and firewall preparation guidance with links to the new section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->