### PR TITLE
ci(deps): group uv_build with the uv renovate group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -122,19 +122,23 @@
             ]
         },
         {
-            "automerge": false,
-            "description": "Build backend (uv_build): its own PR, manual - build-system changes can affect packaging.",
-            "groupName": "uv (build-system)",
+            "automerge": true,
+            "description": "Build backend (uv_build): rides with the uv group so the pinned range moves in the same PR as the toolchain, and automerges with it - CI builds the wheel/sdist and installs the image on every PR. Majors are excluded here so they fall through to the default automerge: false.",
+            "groupName": "uv",
             "matchDepTypes": [
                 "build-system.requires"
             ],
             "matchManagers": [
                 "pep621"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch"
             ]
         },
         {
             "automerge": true,
-            "description": "Keep uv together in one PR (the setup-uv input, the Docker uv image, and the uv-pre-commit hook).",
+            "description": "Keep uv together in one PR (the setup-uv input, the Docker uv image, the uv-pre-commit hook, and - via the build-system rule above - the uv_build backend).",
             "groupName": "uv",
             "matchPackageNames": [
                 "astral-sh/uv",
@@ -145,7 +149,7 @@
         },
         {
             "automerge": false,
-            "description": "uv majors (across managers) get their own manual PR; the uv group otherwise has no update-type filter.",
+            "description": "uv majors (across managers) get their own manual PR; the uv group otherwise has no update-type filter. A uv_build major is not covered by the rule above either, so it defaults to manual as well.",
             "matchPackageNames": [
                 "astral-sh/uv",
                 "astral-sh/uv-pre-commit",


### PR DESCRIPTION
## Summary

Renovate currently splits every uv minor into two PRs: the toolchain group
(`renovate/uv` — setup-uv input, Docker image, uv-pre-commit hook) and a separate
`renovate/uv-(build-system)` for the `uv_build` pin in `build-system.requires`,
which moves in lockstep with it. uv 0.12.0 was about to produce exactly that pair.

This puts `uv_build` on `groupName: "uv"` so both land in one PR, and lets it
automerge with the rest of the group — CI builds the wheel/sdist and the image on
every PR, so the packaging change is exercised before merge.

`uv_build` majors are excluded from the rule and fall through to the default
`automerge: false`, so a major keeps the group PR manual, matching how uv majors
are already handled.

## Security

None — Renovate grouping/automerge policy only, no workflow permissions,
secrets, or firewall logic touched.

## Testing

`prek run renovate-config-validator --all-files` (the repo's pinned validator,
`--strict`) passes. Grouping itself only gets confirmed on the next Renovate run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance for `uv` build backend updates.
  * Minor and patch updates can now be merged automatically.
  * Major updates continue to require manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->