### PR TITLE
ci: add SLSA generator smoke test and gate releases on it

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -48,6 +48,29 @@ git status                      # must be clean
 make lint && make test          # gates must pass
 ```
 
+### 2b. Verify the SLSA generator still works
+
+The release pipeline depends on `slsa-github-generator` v2.1.0, which is
+effectively unmaintained (see the header of
+`.github/workflows/slsa-smoke-test.yaml`). Confirm it still works **before**
+tagging — a failure discovered at tag time means a half-published release.
+
+```bash
+gh workflow run "SLSA generator smoke test" --ref main
+sleep 15 && gh run list --workflow slsa-smoke-test.yaml --limit 1   # get the run ID
+gh run watch <run-id> --exit-status
+```
+
+The run must end green, including the `Verify provenance` job — that job is what
+proves the provenance actually verifies, not just that the generator exited 0.
+
+If it fails, **stop and do not tag**. The release cannot produce valid
+provenance until it's resolved. Options at that point: wait for an upstream fix,
+or drop the generator and fall back to the native `actions/attest` attestations
+that `attest-dist` already produces (which would also mean revising the SLSA 3
+badge and verification docs in `README.md`, since GitHub's artifact attestations
+are documented as SLSA v1 Build L2).
+
 ### 3. Bump the version
 
 Edit `pyproject.toml` `version = "..."` to the release version (drop any
@@ -177,6 +200,7 @@ Merge it (use the `ship-changes` skill if helpful).
 - [ ] Pinned version bumped in `README.md` and
       `.github/ISSUE_TEMPLATE/bug_report.md` (no stale old version remains).
 - [ ] `make lint` and `make test` pass; `make build` produced dist artifacts.
+- [ ] SLSA generator smoke test run green on `main` (step 2b) before tagging.
 - [ ] Release bump landed via a **merged PR** (not a direct push to `main`).
 - [ ] Release commit is signed-off + GPG-signed.
 - [ ] Annotated tag `vX.Y.Z` created on the merged commit, GPG-signed, verifies.
@@ -193,3 +217,6 @@ Merge it (use the `ship-changes` skill if helpful).
 - Tag the **merged** release commit, so the tagged tree's `pyproject.toml`
   version (`X.Y.Z`) matches the tag (`vX.Y.Z`).
 - Branch protection rejects unsigned commits/tags; ensure signing works first.
+- Don't skip the SLSA smoke test (step 2b) because the last release worked. The
+  generator is unmaintained and pinned to `ubuntu-latest` internally, so it can
+  break between releases without anything in this repo changing.

--- a/.github/workflows/slsa-smoke-test.yaml
+++ b/.github/workflows/slsa-smoke-test.yaml
@@ -5,6 +5,14 @@ name: SLSA generator smoke test
 # call the release workflow uses, and verifies the resulting provenance with
 # slsa-verifier.
 #
+# Why this exists: slsa-github-generator is effectively unmaintained. v2.1.0 is
+# from February 2025, the last commit to its main branch was March 2026, and the
+# Renovate PR that would refresh its actions has been open since May 2026. Every
+# job inside the generator also runs on `ubuntu-latest`, which we cannot pin from
+# here — so a runner image roll can break our release with no warning. Run this
+# before cutting a release (see .claude/skills/cut-release) and monthly, so
+# breakage surfaces on a canary instead of on a v* tag.
+#
 # Nothing is released: the generator's `upload-assets` job is gated on
 # `inputs.upload-assets && (tag ref || upload-tag-name != '')`, and we pass
 # `upload-assets: false` from a branch, so that job never runs. No PyPI or
@@ -15,12 +23,16 @@ name: SLSA generator smoke test
 # need a real pushed image digest and are not covered here.
 
 on:
-  # `workflow_dispatch` only appears once this file is on the default branch,
-  # so the push trigger is what makes the smoke test runnable from a branch.
+  # Manual run before cutting a release. Scheduled runs and `workflow_dispatch`
+  # only work from the default branch; the push trigger is what makes the smoke
+  # test runnable from a branch while iterating on this workflow itself.
+  workflow_dispatch:
+  schedule:
+    # Monthly, at an off-peak minute so the run is less likely to be dropped.
+    - cron: "17 6 1 * *"
   push:
     branches:
       - "ci/slsa-smoke-test*"
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/slsa-smoke-test.yaml
+++ b/.github/workflows/slsa-smoke-test.yaml
@@ -1,0 +1,135 @@
+name: SLSA generator smoke test
+
+# Checks that the SLSA generic generator still works before we depend on it
+# during a release. It builds a throwaway subject, runs the same generator
+# call the release workflow uses, and verifies the resulting provenance with
+# slsa-verifier.
+#
+# Nothing is released: the generator's `upload-assets` job is gated on
+# `inputs.upload-assets && (tag ref || upload-tag-name != '')`, and we pass
+# `upload-assets: false` from a branch, so that job never runs. No PyPI or
+# Docker publishing is involved either — this workflow is self-contained.
+#
+# Scope: this only exercises `generator_generic_slsa3.yml` (the Python package
+# release path). The `generator_container_slsa3.yml` calls in `docker.yaml`
+# need a real pushed image digest and are not covered here.
+
+on:
+  # `workflow_dispatch` only appears once this file is on the default branch,
+  # so the push trigger is what makes the smoke test runnable from a branch.
+  push:
+    branches:
+      - "ci/slsa-smoke-test*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-subject:
+    name: Build throwaway subject
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+
+      # A synthetic file keeps the test focused on the generator: it only ever
+      # consumes base64 subjects, so wiring in the real `uv build` would add
+      # failure modes that are not the thing under test.
+      - name: Create subject
+        run: |
+          mkdir -p subject
+          printf 'slsa smoke test %s %s\n' "${GITHUB_SHA}" "${GITHUB_RUN_ID}" \
+            > subject/slsa-smoke-test.txt
+
+      - name: Generate hashes
+        id: hash
+        run: cd subject && echo "hashes=$(sha256sum -- * | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+      - name: Store the subject
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: slsa-smoke-test-subject
+          path: subject/
+          retention-days: 1
+
+  provenance:
+    name: Generate provenance
+    needs:
+      - build-subject
+    # Deliberately identical to the release workflow's permissions so a pass
+    # here means the release path passes. `contents: write` is inert: the only
+    # job that uses it is skipped because `upload-assets` is false.
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    # Can't pin with hash: SLSA verification requires calling the generator
+    # by tag, and GitHub evaluates the ref for nested actions inside it too.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
+    with:
+      base64-subjects: ${{ needs.build-subject.outputs.hashes }}
+      provenance-name: slsa-smoke-test.intoto.jsonl
+      upload-assets: false
+
+  verify:
+    name: Verify provenance
+    needs:
+      - build-subject
+      - provenance
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      # `audit` rather than `block`: slsa-verifier talks to the Sigstore TUF
+      # root and Rekor, and a missing endpoint would look exactly like "the
+      # generator is broken". This workflow's job is to give an unambiguous
+      # answer, so it must not fail for firewall reasons.
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+
+      - name: Download the subject
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: slsa-smoke-test-subject
+          path: subject
+
+      - name: Download the provenance
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.provenance.outputs.provenance-name }}
+          path: provenance
+
+      - name: Install slsa-verifier
+        uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # v2.7.1
+
+      - name: Verify
+        env:
+          PROVENANCE_NAME: ${{ needs.provenance.outputs.provenance-name }}
+          SOURCE_URI: github.com/${{ github.repository }}
+        run: |
+          slsa-verifier verify-artifact subject/slsa-smoke-test.txt \
+            --provenance-path "provenance/${PROVENANCE_NAME}" \
+            --source-uri "${SOURCE_URI}" \
+            --builder-id https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v2.1.0


### PR DESCRIPTION
## Summary

Adds a smoke-test workflow that exercises
`slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0`
end to end without releasing anything, and wires it into the release procedure as a
pre-flight gate.

## Why

Prompted by [slsa-github-generator#4490](https://github.com/slsa-framework/slsa-github-generator/issues/4490).
The Node 20 deprecation in that issue turns out **not** to be the real risk — runners
have been forcing Node 24 since June 16, 2026, and the generator already passes under it
(see the verified run below). September's removal of the Node 20 binary only kills the
`ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` opt-out, which we don't use.

The real risk is that the generator is effectively unmaintained:

- v2.1.0 is from February 2025 and is still the newest release.
- Upstream `main` last saw a commit in March 2026 (a CODEOWNERS edit).
- The Renovate PR that would refresh its actions (#4361) has been open since May 2026.
- Every job inside the generator uses `runs-on: ubuntu-latest`, which callers cannot
  pin or override — an image roll can break our release with no advance warning.

Since the generator only runs on `v*` tags, breakage would otherwise surface *during* a
release, after the tag is pushed and half the pipeline has run.

## What it does

1. `build-subject` — writes one throwaway file and emits `base64-subjects`. Deliberately
   not `uv build`: the generator only consumes hashes, so coupling to the real build
   would add failure modes that aren't under test.
2. `provenance` — calls the generator with the **exact** permissions block
   `python-package.yaml` uses (`actions: read`, `id-token: write`, `contents: write`),
   but `upload-assets: false`.
3. `verify` — downloads the provenance and runs `slsa-verifier verify-artifact` against
   it. This is the part that proves provenance actually verifies, rather than that the
   generator merely exited 0.

Triggers: manual (`workflow_dispatch`) before a release, plus a monthly schedule, plus
pushes to `ci/slsa-smoke-test*` for iterating on the workflow itself.

`.claude/skills/cut-release/SKILL.md` gains step 2b requiring a green run before tagging,
with instructions to stop rather than tag if it fails.

## Nothing is released

The generator's `upload-assets` job is gated on
`inputs.upload-assets && (startsWith(github.ref, 'refs/tags/') || inputs.upload-tag-name != '')`.
Passing `upload-assets: false` from a non-tag ref means that job never runs — it shows as
skipped in the run below, and no release or draft was created.

## Verified

Run [30473384529](https://github.com/jkreileder/cf-ips-to-hcloud-fw/actions/runs/30473384529)
on this branch passed:

```
Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v2.1.0"
Verifying artifact subject/slsa-smoke-test.txt: PASSED
PASSED: SLSA verification passed
```

## Known limitations

- The generator's `upload-assets` job is skipped here, so `secure-builder-checkout`
  (→ `actions/checkout@v4.2.2`) and `secure-download-artifact`
  (→ `actions/download-artifact@v4.1.8`) are not exercised. Covering them would require
  `upload-assets: true` + `upload-tag-name` + `draft-release: true`, which creates a
  deletable draft release — rejected to keep the "touches nothing" property. Risk is low;
  both are among the most-run actions on the platform.
- Only `generator_generic_slsa3.yml` is covered. The three
  `generator_container_slsa3.yml` call sites in `docker.yaml` need a real pushed image
  digest and remain unverified.
- `egress-policy: audit` in the `verify` job rather than `block`: slsa-verifier talks to
  the Sigstore TUF root and Rekor, and a missing allowlist entry would look identical to
  "the generator is broken". This workflow's job is to give an unambiguous answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated monthly and on-demand smoke test for SLSA provenance generation and verification.
  * Added safeguards to prevent releases from being tagged when provenance validation fails.
  * Added verification of generated provenance against the expected source and builder identity.
  * Updated release guidance and checklists to require a successful smoke test before tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->