### PR TITLE
ci(trufflehog): pin scanner image and exclude Lob detector

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,18 @@
             "matchStrings": [
                 "image=(?<depName>moby/buildkit):(?<currentValue>v[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
             ]
+        },
+        {
+            "customType": "regex",
+            "datasourceTemplate": "docker",
+            "depNameTemplate": "ghcr.io/trufflesecurity/trufflehog",
+            "description": "Pin the TruffleHog scanner image (version input of trufflesecurity/trufflehog) by version + digest.",
+            "managerFilePatterns": [
+                ".github/workflows/trufflehog.yaml"
+            ],
+            "matchStrings": [
+                "version: (?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+            ]
         }
     ],
     "extends": [

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -29,14 +29,8 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: block
-          # api.lob.com is TruffleHog's Lob-detector verification endpoint: a
-          # candidate in the scanned history trips that detector, and with
-          # verification enabled TruffleHog dials Lob to confirm it. Allow the
-          # host so verification actually runs (returns a definite verified/not
-          # result) instead of a blocked DNS lookup tripping harden-runner.
           allowed-endpoints: >
             api.github.com:443
-            api.lob.com:443
             ghcr.io:443
             github.com:443
             pkg-containers.githubusercontent.com:443
@@ -51,4 +45,11 @@ jobs:
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
           path: .
-          extra_args: --results=verified,unknown
+          # `version` selects the scanner image and defaults to latest; the action pin
+          # alone leaves it floating. Renovate bumps the version + digest.
+          version: 3.96.0@sha256:aa821cf4ace8861c7d096d83818cdf7bb9719028a52d37a52eaad44086a52577
+          # Lob excluded: the reordered-is-noop test name (tests/test_firewall.py) is
+          # test_ + exactly 35 word chars, matching Lob's key pattern; TruffleHog verifies
+          # it against Cloudflare-fronted api.lob.com, whose bot-block 403 the detector
+          # reads as a successful verification.
+          extra_args: --results=verified,unknown --exclude-detectors=lob


### PR DESCRIPTION
## Summary

The secret scan fails intermittently on branch pushes with
`Found verified Lob result 🐷🔑` (e.g. [run 31125333971](https://github.com/jkreileder/cf-ips-to-hcloud-fw/actions/runs/31125333971)).
It is a false positive, and #1404 did not introduce it — nothing in that diff
can match a Lob key.

The reordered-is-noop pytest name in `tests/test_firewall.py` (added in #1274)
is `test_` plus exactly 35 word characters, which is precisely TruffleHog's Lob
key pattern `\b((live|test)_[a-zA-Z0-9_]{35})\b`. TruffleHog verifies the
candidate by POSTing to `api.lob.com`, which sits behind Cloudflare; the
detector treats HTTP 403 as a successful verification, so a bot-block turns the
candidate into a "verified" secret. A 401 (what the endpoint returns normally)
is filtered out, which is why most runs are green.

Renaming the test would not fix it. A branch-creation push scans with
`BASE=""` and `fetch-depth: 0` — the failing run covered 4.27 MB / 5463 chunks
against a 386 KB worktree — so the string stays visible in commit 6a6bfeb
regardless. Excluding the detector removes both the candidate and the
third-party network dependency, so `api.lob.com` comes off the harden-runner
allowlist too. This project has no relationship to Lob.

Also pins the scanner image. The action pin only fixes the wrapper; its
`version` input selects the image that actually runs and defaults to `latest`,
so a newly shipped detector can dial a host the allowlist does not cover and
fail the scan the same way — the shape of the earlier `api.lob.com` breakage
this workflow was already patched for. A Renovate custom manager keeps the
version and digest current, matching the existing `scout-sbom-indexer` /
`binfmt` / `buildkit` entries.

Note that #1404 will not go green from a re-run: push events use the workflow
file at the pushed commit, so that branch needs a rebase onto a `main` that
contains this change.

## Security

No change to token or firewall-rule handling. Secret-scanning coverage narrows
by exactly one detector (Lob), and the harden-runner egress allowlist shrinks
by one host. Pinning the scanner image by digest tightens supply-chain
provenance — the workflow previously ran a floating `:latest`.

## Testing

- `make check` — 75 passed, 100% coverage.
- `prek run --files .github/workflows/trufflehog.yaml .github/renovate.json` —
  actionlint, zizmor, gitleaks, and renovate-config-validator all pass.
- Confirmed against the pinned TruffleHog 3.96.0 that `--exclude-detectors=lob`
  suppresses the detector, and that an unknown detector name hard-errors
  (`unrecognized detector type`) rather than being silently ignored.
- `docker pull ghcr.io/trufflesecurity/trufflehog:3.96.0@sha256:aa821cf4…`
  resolves; the digest is a multi-arch manifest list (linux/amd64 +
  linux/arm64) and matches what the registry reports for tag `3.96.0`.
- Parsed the workflow YAML to confirm the new comments do not leak into the
  `version` or `extra_args` values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated TruffleHog scanning to version 3.96.0 with a verified image digest.
  * Refined secret scanning to retain verified and unknown findings while excluding the Lob detector.
  * Restricted hardened workflow network access to required GitHub services.

* **Maintenance**
  * Added automated tracking for TruffleHog version and digest updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->