### PR TITLE
ci(docker): drop bundled pip and report only fixable CVEs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -298,6 +298,11 @@ jobs:
           dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
           command: cves${{ !startsWith(github.ref, 'refs/tags/') && ',recommendations,compare' || '' }}
           image: ${{ vars.DOCKERHUB_USERNAME }}/cf-ips-to-hcloud-fw:${{ steps.docker-meta.outputs.version }}
+          # Match Grype's only-fixed policy: report only actionable findings.
+          # Unfixable base-image CVEs surface once a fix ships and are then
+          # resolved by the next Renovate digest bump. Trade-off: disclosure of
+          # an unfixed critical isn't flagged here until a fix exists.
+          only-fixed: true
           sarif-file: sarif.output.json
           organization: ${{ vars.DOCKERHUB_USERNAME }}
           to: registry://${{ vars.DOCKERHUB_USERNAME }}/cf-ips-to-hcloud-fw:1

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ ENV PYTHONFAULTHANDLER=1 PYTHONDONTWRITEBYTECODE=1
 # SBOM of its vendored libraries (pip/_vendor/bom.cdx.json), which makes
 # scanners report CVEs against vendored setuptools/msgpack that are never used.
 RUN rm -rf /usr/local/lib/python3.*/site-packages/pip \
-           /usr/local/lib/python3.*/site-packages/pip-*.dist-info
+           /usr/local/lib/python3.*/site-packages/pip-*.dist-info \
+           /usr/local/bin/pip*
 
 # Resolve and install dependencies
 RUN --mount=type=bind,from=uv-tools-alpine,source=/usr/local/bin/uv,target=/usr/local/bin/uv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,13 @@ WORKDIR /usr/src/app
 
 ENV PYTHONFAULTHANDLER=1 PYTHONDONTWRITEBYTECODE=1
 
+# Drop the base image's bundled pip: uv creates .venv without pip and the app
+# runs from .venv/bin, so nothing here imports it. pip ≥26.2 ships a CycloneDX
+# SBOM of its vendored libraries (pip/_vendor/bom.cdx.json), which makes
+# scanners report CVEs against vendored setuptools/msgpack that are never used.
+RUN rm -rf /usr/local/lib/python3.*/site-packages/pip \
+           /usr/local/lib/python3.*/site-packages/pip-*.dist-info
+
 # Resolve and install dependencies
 RUN --mount=type=bind,from=uv-tools-alpine,source=/usr/local/bin/uv,target=/usr/local/bin/uv \
     --mount=target=pyproject.toml,source=/pyproject.toml \


### PR DESCRIPTION
## Summary

`python:3.14.7-alpine3.24` bumped the bundled pip to 26.2.1, which now ships a CycloneDX SBOM of
its 19 vendored libraries (`pip/_vendor/bom.cdx.json`). Scout and Grype read it, so [run
31154118532](https://github.com/jkreileder/cf-ips-to-hcloud-fw/actions/runs/31154118532) started
reporting CVE-2025-47273 / CVE-2026-59890 (vendored setuptools 70.3.0, pinned indefinitely by pip
for `pkg_resources`) and GHSA-6v7p-g79w-8964 (vendored msgpack 1.1.2) — code that was always in the
image but never visible to scanners, and never imported: uv creates `.venv` without pip and the app
runs from `.venv/bin`.

Two changes:

- **Dockerfile**: remove pip from the final stage. Fixes the whole class at the source instead of
  whitelisting per CVE in two scanner-specific formats, and covers future advisories against pip's
  vendored tree. (No size win — pip stays in the base layer; the `rm` adds a ~1.5 KB whiteout.)
- **docker.yaml**: add `only-fixed: true` to the Scout step, matching Grype's existing policy so
  both scanners report only actionable findings. Unfixable base-image CVEs surface once a fix
  ships and are then resolved by the next Renovate digest bump. Trade-off: disclosure of an
  unfixed critical isn't flagged until a fix exists. Scans stay `continue-on-error` (advisory) —
  they run after push/sign, so failing the job couldn't stop publication anyway.

## Security

No token or firewall-rule impact. Removes an unused package-installer (pip) from the runtime
image, slightly reducing attack surface; CVE scans become strictly less noisy but no less
sensitive to actionable findings.

## Testing

- Built the final stage with the `rm` on linux/amd64: `uv sync --frozen` works, stdlib and all
  runtime deps import, smoke test passes.
- `docker scout sbom` on the result lists only the 20 runtime deps — no pip/setuptools/msgpack
  (19 vendored pypi entries on the unpatched image).
- Verified the glob `rm` in busybox sh of the exact base image.
- `make check` — 75 passed, 100% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Vulnerability scanning now reports only issues with available fixes, making results more actionable.
  * Removed the bundled package installer from the final container image to reduce unnecessary components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->