### PR TITLE
ci(rescan): allow raw.githubusercontent.com for the grype installer

### DIFF
--- a/.github/workflows/rescan.yaml
+++ b/.github/workflows/rescan.yaml
@@ -36,9 +36,10 @@ jobs:
           egress-policy: block
           # Subset of the docker.yaml allowlist: Docker Hub pulls, the Scout
           # API/CLI and its two d*.cloudfront.net vulnerability-data CDN
-          # distributions, the Grype binary (GitHub releases) and its DB, and
-          # the SARIF upload. If Docker or Anchore rotate hosts, update the
-          # names from the harden-runner insights of the failing run.
+          # distributions, the Grype installer (raw.githubusercontent.com) and
+          # binary (GitHub releases) and its DB, and the SARIF upload. If
+          # Docker or Anchore rotate hosts, update the names from the
+          # harden-runner insights of the failing run.
           allowed-endpoints: >
             api.dso.docker.com:443
             api.github.com:443
@@ -55,6 +56,7 @@ jobs:
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
+            raw.githubusercontent.com:443
             registry-1.docker.io:443
             registry.scout.docker.com:443
             release-assets.githubusercontent.com:443


### PR DESCRIPTION
## Summary

The first `workflow_dispatch` run of the rescan workflow
([31192823259](https://github.com/jkreileder/cf-ips-to-hcloud-fw/actions/runs/31192823259))
failed at the Grype step: `anchore/scan-action` downloads grype via
`https://raw.githubusercontent.com/anchore/grype/main/install.sh`, which wasn't in the egress
allowlist (harden-runner: `dns-request-dropped`, `matchedPolicy=NONE`). This was the anticipated
allowlist-validation failure noted in #1409's testing section — everything before the Grype step
(Docker Hub pulls, Scout scan + SARIF upload) worked.

Adds `raw.githubusercontent.com:443`, matching the host already allowed in `docker.yaml`.

## Security

Widens the rescan workflow's egress allowlist by one read-only host that `docker.yaml` already
allows. No token or firewall-rule impact.

## Testing

Will dispatch the workflow again after merge; expected result is a completed Grype scan (run may
still legitimately go red if it finds fixable CVEs — that's the workflow's purpose).