### PR TITLE
ci(grype): ignore CPython CVEs whose fix exists only in the 3.15 stream

### DIFF
--- a/.github/workflows/rescan.yaml
+++ b/.github/workflows/rescan.yaml
@@ -62,6 +62,13 @@ jobs:
             release-assets.githubusercontent.com:443
             uploads.github.com:443
 
+      # Grype auto-detects .grype.yaml in the workspace; without the checkout
+      # the rescan would ignore fewer findings than the build-time scan.
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       # Scout needs Docker Hub credentials for its API; no docker login has
       # happened in this workflow, so pass them as inputs (same pattern as
       # docker.yaml). exit-code makes fixable findings fail the step.

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,42 @@
+# Grype ignore rules — every entry MUST state its removal condition.
+#
+# Tracking issue for clearing this list: #1412. Do not let entries outlive
+# their condition.
+#
+# CPython CVEs matched against the interpreter binary in the
+# python:3.14.x-alpine base image. Grype lists them as "fixed" only in the
+# 3.15 stream (3.15.0a6/b3/b4/3.15.0); the 3.14-branch backports are merged
+# upstream but unreleased, so no base-image bump can clear them yet and
+# only-fixed does not filter them.
+# REMOVE when the Dockerfile base image reaches python >= 3.14.8 (expected to
+# carry the backports) — delete the entries, run the Docker workflow, and
+# confirm the Grype step stays green.
+ignore:
+  - vulnerability: CVE-2026-15308
+    package:
+      name: python
+      type: binary
+  - vulnerability: CVE-2026-11972
+    package:
+      name: python
+      type: binary
+  - vulnerability: CVE-2026-11940
+    package:
+      name: python
+      type: binary
+  - vulnerability: CVE-2026-12003
+    package:
+      name: python
+      type: binary
+  - vulnerability: CVE-2026-0864
+    package:
+      name: python
+      type: binary
+  - vulnerability: CVE-2025-15366
+    package:
+      name: python
+      type: binary
+  - vulnerability: CVE-2025-15367
+    package:
+      name: python
+      type: binary


### PR DESCRIPTION
## Summary

The Grype step fails on both the `:main` build scan and the daily `:1` rescan: its binary
cataloger fingerprints the CPython interpreter in the `python:3.14.x-alpine` base and the Aug 6 DB
update added seven CVEs against it (3 high, 4 medium — CVE-2026-15308, CVE-2026-11972,
CVE-2026-11940, CVE-2026-12003, CVE-2026-0864, CVE-2025-15366, CVE-2025-15367). Their fixed-in
versions are all in the **3.15 stream** (3.15.0a6/b3/b4/3.15.0); the 3.14-branch backports are
merged upstream but not in any released 3.14.x. So `only-fixed: true` passes them (a fix exists),
while nothing we can ship — including a release rebuild — clears them.

- Add `.grype.yaml` ignoring exactly these seven CVEs, scoped to the `python` binary package, with
  the removal condition in the file header.
- Add a checkout step to `rescan.yaml` — Grype auto-detects `.grype.yaml` in the workspace, and
  the rescan job had no checkout, so it would otherwise keep failing while the build scan passes.

**Clearing the list is tracked in #1412**: once the base reaches `python` ≥ 3.14.8, the entries
get deleted (details and close condition in the issue).

Scout needs no counterpart — it doesn't catalog interpreter binaries, which is why only Grype
went red.

## Security

Suppresses exactly seven named CVEs against the base-image interpreter that have no shippable fix;
scoped to the `python` binary package so any other finding — including future CPython CVEs — still
surfaces. No token or firewall-rule impact.

## Testing

- Reproduced the failure locally: `grype docker.io/jkreileder/cf-ips-to-hcloud-fw:main
  --only-fixed` → the seven CVEs, all `FIXED IN` 3.15.x.
- Same scan with this `.grype.yaml` in the working directory → "No vulnerabilities found".
- `actionlint`/`zizmor` pass on the workflow change (pre-commit). The rescan path gets validated
  by the next scheduled/dispatched run after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability scanning to apply the repository’s scanning configuration.
  * Added documented exceptions for seven known Python binary vulnerabilities in the Alpine-based runtime image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->