### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ debug logs).
 
 **Environment**<!-- markdownlint-disable-line MD036 -->
 
-- cf-ips-to-hcloud-fw version: [e.g. 1.3.0]
+- cf-ips-to-hcloud-fw version: [e.g. 1.3.1]
 - Deployment method: [e.g. Docker, Python module]
 - If Python module, Python version: [e.g. 3.14]
 - If Python module, OS: [e.g. macOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.3.1] – Unreleased
+## [v1.3.1] – 2026-08-12
 
-- Start new development cycle
 - Hardened Hetzner firewall updates: the CLI now waits for each asynchronous
   `set_rules` action to finish (surfacing action failures and timeouts instead of
   reporting success at submission), applies a bounded connect/read timeout so a
@@ -16,6 +15,10 @@
   version exactly and that version is a final `X.Y.Z` release (no `.dev`,
   pre-release, or local component), preventing a wrong or non-final version from
   reaching PyPI or producing mismatched Docker semver tags
+- Maintenance: dependency updates and CI hardening — daily CVE rescans of the
+  released Docker image, malware scanning of locked dependencies (plus a `make
+  audit` target), and a smoke test that gates releases on the SLSA generator
+  still working
 
 ## [v1.3.0] – 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.3.0
+  jkreileder/cf-ips-to-hcloud-fw:1.3.1
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -161,7 +161,7 @@ command override is needed:
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
   -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
-  jkreileder/cf-ips-to-hcloud-fw:1.3.0
+  jkreileder/cf-ips-to-hcloud-fw:1.3.1
 ```
 
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
@@ -169,7 +169,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.3`: This tag always points to the latest `1.3.x` release.
-- `1.3.0`: This tag points to the specific `1.3.0` release.
+- `1.3.1`: This tag points to the specific `1.3.1` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -221,7 +221,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.3.0
+              image: jkreileder/cf-ips-to-hcloud-fw:1.3.1
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false
@@ -248,7 +248,7 @@ falls back to these variables:
 ```yaml
 containers:
   - name: cf-ips-to-hcloud-fw
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.0
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.1
     env:
       - name: HCLOUD_TOKEN
         valueFrom:
@@ -451,7 +451,7 @@ service that uses the image's default one-shot entrypoint:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.0
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.1
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
 ```
@@ -471,7 +471,7 @@ the `docker compose run` line above, or the override makes the run never exit:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.0
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.1
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
     # Re-run every 24h (86400s) inside one container instead of a scheduler.
@@ -507,7 +507,7 @@ attest get` after verifying build provenance.
 
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.3.0
+VERSION=1.3.1
 
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
@@ -535,7 +535,7 @@ Build provenance:
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
 IMAGE_REPO=docker.io/jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.3.0
+VERSION=1.3.1
 IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 
 # Verifying build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.3.1.dev1"
+version = "1.3.1"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.3.1.dev1"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Release v1.3.1. Bumps the version, finalizes the changelog, and updates the pinned version in docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 1.3.1 is now available.
  * Added support and documentation for the 1.3.1 Docker image tag.

* **Documentation**
  * Updated Docker, Kubernetes, Compose, and attestation examples to use version 1.3.1.
  * Updated the bug report template with the latest example version.
  * Added release notes covering ongoing security scanning and release validation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->