### PR TITLE
ci(release): attest Python dists from a reusable workflow for SLSA L3

### DIFF
--- a/.github/workflows/build-and-attest-dist.yaml
+++ b/.github/workflows/build-and-attest-dist.yaml
@@ -1,0 +1,155 @@
+name: Build and attest distribution
+
+# Reusable build + attest path for the Python wheel and sdist. The build and
+# the attestation generation live together in this reusable workflow so the
+# GitHub artifact attestations qualify for SLSA Build Level 3: the signed
+# provenance records this workflow file as the signer (its job_workflow_ref),
+# which the calling workflow cannot influence beyond invoking it. Verifiers
+# can require it:
+#
+#   gh attestation verify <artifact> --repo jkreileder/cf-ips-to-hcloud-fw \
+#     --signer-workflow jkreileder/cf-ips-to-hcloud-fw/.github/workflows/build-and-attest-dist.yaml
+#
+# Event gating (non-PR push) and the test/version-check ordering live in the
+# calling workflow (python-package.yaml).
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build-dist:
+    name: Build distribution
+    # Builds the publishable sdist/wheel, read-only. The privileged attestation
+    # happens in attest-dist, which only downloads these artifacts.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            files.pythonhosted.org:443
+            get.anchore.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            releases.astral.sh:443
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python and install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "3.11"
+          version: "0.12.3"
+          # Keep the published artifacts hermetic: never restore caches here.
+          enable-cache: false
+
+      - name: Build
+        run: |
+          rm -rf dist
+          uv build
+
+      - name: Smoke test built wheel
+        run: |
+          uv run --isolated --no-project --with dist/*.whl \
+            cf-ips-to-hcloud-fw --version
+
+      # Write the SBOM to the repo root only; attest-dist re-uploads it under a
+      # name we control (below), so we upload once, explicitly, with the same
+      # pinned action as everything else instead of relying on sbom-action's
+      # internal artifact naming.
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          format: spdx-json
+          output-file: sbom-python.spdx.json
+          upload-artifact: false
+
+      - name: Store the SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-python.spdx.json
+          path: sbom-python.spdx.json
+          retention-days: 14
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+          retention-days: 14
+
+  attest-dist:
+    name: Attest distribution
+    # Minimal privileged job: it only downloads the already-built distribution
+    # and SBOM and attests them. It never checks out or runs repository code, so
+    # id-token/attestations write never touches a build step. The dependabot
+    # guard mirrors the original attestation steps and the repo's policy of not
+    # running privileged jobs as dependabot; the calling workflow's triggers
+    # (push to main / v* tags) don't fire for dependabot, so it is defensive
+    # only.
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs:
+      - build-dist
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            objects.githubusercontent.com:443
+            rekor.sigstore.dev:443
+            uploads.github.com:443
+
+      - name: Download the distribution packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Download the SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom-python.spdx.json
+          path: sbom
+
+      - name: Generate SBOM attestation
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
+          sbom-path: sbom/sbom-python.spdx.json
+
+      - name: Generate artifact attestation
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -308,159 +308,36 @@ jobs:
           fi
           echo "Release version '$version' matches tag $TAG"
 
-  build-dist:
-    name: Build distribution
-    # Build the publishable sdist/wheel once per non-PR push (main and tags),
-    # read-only. Gated on the full test matrix so a tag with failing tests never
-    # builds or publishes, and on check-release-version so a mistaken tag fails
-    # before anything is built (on main that check is a no-op pass). The
-    # privileged attestation happens in attest-dist, which only downloads these
-    # artifacts.
+  build-and-attest-dist:
+    name: Build and attest distribution
+    # Build and attestation run together inside a reusable workflow so the
+    # GitHub artifact attestations qualify for SLSA Build Level 3 — the signed
+    # provenance records that workflow file as the signer (see the header of
+    # build-and-attest-dist.yaml). Runs once per non-PR push (main and tags),
+    # gated on the full test matrix so a tag with failing tests never builds
+    # or publishes, and on check-release-version so a mistaken tag fails
+    # before anything is built (on main that check is a no-op pass).
     if: ${{ github.event_name != 'pull_request' }}
     needs:
       - test
       - check-release-version
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            files.pythonhosted.org:443
-            get.anchore.io:443
-            github.com:443
-            objects.githubusercontent.com:443
-            pypi.org:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            releases.astral.sh:443
-
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Set up Python and install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          python-version: "3.11"
-          version: "0.12.3"
-          # Keep the published artifacts hermetic: never restore caches here.
-          enable-cache: false
-
-      - name: Build
-        run: |
-          rm -rf dist
-          uv build
-
-      - name: Smoke test built wheel
-        run: |
-          uv run --isolated --no-project --with dist/*.whl \
-            cf-ips-to-hcloud-fw --version
-
-      # Write the SBOM to the repo root only; attest-dist re-uploads it under a
-      # name we control (below), so we upload once, explicitly, with the same
-      # pinned action as everything else instead of relying on sbom-action's
-      # internal artifact naming.
-      - name: Generate SBOM
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          format: spdx-json
-          output-file: sbom-python.spdx.json
-          upload-artifact: false
-
-      - name: Store the SBOM
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: sbom-python.spdx.json
-          path: sbom-python.spdx.json
-          retention-days: 14
-
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: python-package-distributions
-          path: dist/
-          retention-days: 14
-
-  attest-dist:
-    name: Attest distribution
-    # Minimal privileged job: it only downloads the already-built distribution
-    # and SBOM and attests them. It never checks out or runs repository code, so
-    # id-token/attestations write never touches a build step. The dependabot
-    # guard mirrors the original attestation steps and the repo's policy of not
-    # running privileged jobs as dependabot; these triggers (push to main / v*
-    # tags) don't fire for dependabot, so it is defensive only.
-    if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
-    needs:
-      - build-dist
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
       attestations: write
-
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            fulcio.sigstore.dev:443
-            github.com:443
-            objects.githubusercontent.com:443
-            rekor.sigstore.dev:443
-            uploads.github.com:443
-
-      - name: Download the distribution packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: python-package-distributions
-          path: dist
-
-      - name: Download the SBOM
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: sbom-python.spdx.json
-          path: sbom
-
-      - name: Generate SBOM attestation
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: |
-            dist/*.whl
-            dist/*.tar.gz
-          sbom-path: sbom/sbom-python.spdx.json
-
-      - name: Generate artifact attestation
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-path: |
-            dist/*.whl
-            dist/*.tar.gz
+    uses: ./.github/workflows/build-and-attest-dist.yaml
 
   draft-release:
     name: Create draft release
     # Replaces the retired slsa-github-generator call (the project is no longer
     # maintained): build provenance comes from the GitHub artifact attestations
-    # that attest-dist publishes for every artifact (verified with
+    # that build-and-attest-dist publishes for every artifact (verified with
     # `gh attestation verify`, see README.md), so this job only creates the
     # draft release that the publish chain and upload-dist-to-github-release
     # depend on. It never checks out or runs repository code.
     if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
     needs:
-      - build-dist
-      - attest-dist
+      - build-and-attest-dist
       - upload-event-file
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   published for the image on all three registries (`push-to-registry`, verified
   with `gh attestation verify oci://…`), alongside the BuildKit inline SBOM and
   provenance
+- Moved the Python build and attestation into a reusable workflow
+  (`build-and-attest-dist.yaml`) so the artifact attestations qualify for SLSA
+  Build Level 3 per GitHub's guidance; verifiers can require the signer with
+  `gh attestation verify --signer-workflow
+  jkreileder/cf-ips-to-hcloud-fw/.github/workflows/build-and-attest-dist.yaml`
 
 ## [v1.3.1] – 2026-08-12
 


### PR DESCRIPTION
Phase 3a of the SLSA migration. GitHub artifact attestations qualify for SLSA Build Level 3 when the build and the attestation generation run inside a reusable workflow, whose `job_workflow_ref` the signed provenance records as the signer. Moves the `build-dist` and `attest-dist` jobs verbatim into `build-and-attest-dist.yaml` (`workflow_call`); event gating and the test/version-check ordering stay in the caller. Verify with `gh attestation verify --signer-workflow jkreileder/cf-ips-to-hcloud-fw/.github/workflows/build-and-attest-dist.yaml`.