### PR TITLE
docs: update SLSA verification docs and release skill for GitHub attestations

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -48,29 +48,6 @@ git status                      # must be clean
 make lint && make test          # gates must pass
 ```
 
-### 2b. Verify the SLSA generator still works
-
-The release pipeline depends on `slsa-github-generator` v2.1.0, which is
-effectively unmaintained (see the header of
-`.github/workflows/slsa-smoke-test.yaml`). Confirm it still works **before**
-tagging — a failure discovered at tag time means a half-published release.
-
-```bash
-gh workflow run "SLSA generator smoke test" --ref main
-sleep 15 && gh run list --workflow slsa-smoke-test.yaml --limit 1   # get the run ID
-gh run watch <run-id> --exit-status
-```
-
-The run must end green, including the `Verify provenance` job — that job is what
-proves the provenance actually verifies, not just that the generator exited 0.
-
-If it fails, **stop and do not tag**. The release cannot produce valid
-provenance until it's resolved. Options at that point: wait for an upstream fix,
-or drop the generator and fall back to the native `actions/attest` attestations
-that `attest-dist` already produces (which would also mean revising the SLSA 3
-badge and verification docs in `README.md`, since GitHub's artifact attestations
-are documented as SLSA v1 Build L2).
-
 ### 3. Bump the version
 
 Edit `pyproject.toml` `version = "..."` to the release version (drop any
@@ -165,7 +142,9 @@ Pushing the tag starts the publish pipeline. Report the Actions URL:
 
 ### 9. Publish the draft release
 
-CI creates a **draft** GitHub release with provenance/SBOM/attestations.
+CI creates an empty **draft** GitHub release; the dists are attached after the
+PyPI publish, and provenance/SBOM attestations live in GitHub's attestation
+store (verify with `gh attestation verify`, see README.md).
 Once the workflows succeed, review and publish it:
 
 ```bash
@@ -200,7 +179,6 @@ Merge it (use the `ship-changes` skill if helpful).
 - [ ] Pinned version bumped in `README.md` and
       `.github/ISSUE_TEMPLATE/bug_report.md` (no stale old version remains).
 - [ ] `make lint` and `make test` pass; `make build` produced dist artifacts.
-- [ ] SLSA generator smoke test run green on `main` (step 2b) before tagging.
 - [ ] Release bump landed via a **merged PR** (not a direct push to `main`).
 - [ ] Release commit is signed-off + GPG-signed.
 - [ ] Annotated tag `vX.Y.Z` created on the merged commit, GPG-signed, verifies.
@@ -217,6 +195,3 @@ Merge it (use the `ship-changes` skill if helpful).
 - Tag the **merged** release commit, so the tagged tree's `pyproject.toml`
   version (`X.Y.Z`) matches the tag (`vX.Y.Z`).
 - Branch protection rejects unsigned commits/tags; ensure signing works first.
-- Don't skip the SLSA smoke test (step 2b) because the last release worked. The
-  generator is unmaintained and pinned to `ubuntu-latest` internally, so it can
-  break between releases without anything in this repo changing.

--- a/README.md
+++ b/README.md
@@ -503,6 +503,13 @@ the signatures. For GitHub-hosted artifacts you can further restrict verificatio
 with `--signer-workflow`. Container attestations can be fetched with `docker scout
 attest get` after verifying build provenance.
 
+The attestations qualify for [SLSA Build Level 3](https://slsa.dev/spec/v1.0/levels):
+the build and the attestation signing run inside dedicated reusable workflows
+(`build-and-attest-dist.yaml` for the Python distributions, `docker-build.yaml` for
+the container images), which the `--signer-workflow` checks below pin.
+For v1.3.1 and earlier the signer workflow was `python-package.yaml` (Python) or
+`docker.yaml` (Docker) — substitute those paths when verifying older artifacts.
+
 ### Verifying Python Wheels and Source Code
 
 ```shell
@@ -512,23 +519,24 @@ VERSION=1.3.1
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
   --repo $GH_REPO \
-  --signer-workflow $GH_REPO/.github/workflows/python-package.yaml@refs/tags/v$VERSION
+  --signer-workflow $GH_REPO/.github/workflows/build-and-attest-dist.yaml@refs/tags/v$VERSION
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION.tar.gz \
   --repo $GH_REPO \
-  --signer-workflow $GH_REPO/.github/workflows/python-package.yaml@refs/tags/v$VERSION
+  --signer-workflow $GH_REPO/.github/workflows/build-and-attest-dist.yaml@refs/tags/v$VERSION
 
 # Verifying and showing SBOM (only available for the the wheel)
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
   --repo $GH_REPO \
-  --signer-workflow $GH_REPO/.github/workflows/python-package.yaml@refs/tags/v$VERSION \
+  --signer-workflow $GH_REPO/.github/workflows/build-and-attest-dist.yaml@refs/tags/v$VERSION \
   --predicate-type https://spdx.dev/Document/v2.3
 # Add --format json --jq '.[].verificationResult.statement.predicate' to also output the SBOM
 ```
 
 ### Verifying Docker Images
 
-It's recommended that you use an immutable image reference (pin to a digest) to avoid
-[TOCTOU attacks](https://github.com/slsa-framework/slsa-verifier?tab=readme-ov-file#toctou-attacks).
+It's recommended that you use an immutable image reference (pin to a digest) so the
+image you verify is exactly the image you run — a mutable tag can be repointed
+between verification and use (a time-of-check/time-of-use attack).
 
 Build provenance:
 
@@ -541,7 +549,7 @@ IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 # Verifying build provenance
 gh attestation verify oci://$IMAGE \
   --repo $GH_REPO \
-  --signer-workflow $GH_REPO/.github/workflows/docker.yaml@refs/tags/v$VERSION
+  --signer-workflow $GH_REPO/.github/workflows/docker-build.yaml@refs/tags/v$VERSION
 
 # The SBOMs are attached to the now verified image, you can view with
 DIGEST=$(docker scout attest list --format json $IMAGE --predicate-type https://spdx.dev/Document \


### PR DESCRIPTION
Final phase of the SLSA migration. Points the README `--signer-workflow` examples at the reusable workflows that now sign the attestations (with a note that v1.3.1 and earlier were signed by `python-package.yaml` / `docker.yaml`), inlines the TOCTOU digest-pinning rationale instead of linking the retired slsa-verifier README, and drops the SLSA generator smoke-test step from the cut-release skill.