### PR TITLE
ci(tests): skip result publishing for cancelled upstream runs

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -26,7 +26,11 @@ jobs:
     name: Publish test results
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
+    # Skip cancelled runs too: a run cancelled by concurrency (superseded
+    # push) or deleted afterwards has no test artifacts, so the download step
+    # would fail on nothing to publish. Failed runs still publish — a red test
+    # run must report its results.
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' && github.event.workflow_run.conclusion != 'cancelled' }}
 
     permissions:
       checks: write


### PR DESCRIPTION
The JUnit publisher fires via `workflow_run` for every completed python-package run, including ones cancelled by the concurrency group (superseded pushes — several occurred while landing the SLSA migration stack). Cancelled runs never uploaded test artifacts, so the download step's `if_no_artifact_found: fail` produced red "Publish test results" runs on main with nothing actually wrong.

Skip `cancelled` conclusions the same way `skipped` already is. Genuinely failed test runs still publish — a red test run must report its results.