### PR TITLE
chore(release): v1.3.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ debug logs).
 
 **Environment**<!-- markdownlint-disable-line MD036 -->
 
-- cf-ips-to-hcloud-fw version: [e.g. 1.3.1]
+- cf-ips-to-hcloud-fw version: [e.g. 1.3.2]
 - Deployment method: [e.g. Docker, Python module]
 - If Python module, Python version: [e.g. 3.14]
 - If Python module, OS: [e.g. macOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.3.2] – Unreleased
+## [v1.3.2] – 2026-08-12
 
-- Start new development cycle
+Provenance-migration release: the retired `slsa-github-generator` is fully replaced by
+GitHub artifact attestations signed from dedicated reusable workflows (SLSA Build
+Level 3). The CLI itself is unchanged from v1.3.1.
+
 - Replaced the retired `slsa-github-generator` provenance for Python release
   artifacts with GitHub artifact attestations (the generator project is no
   longer maintained). Attestations were already published for every wheel and
@@ -26,6 +29,11 @@
   (`docker-build.yaml`) for the same SLSA Build Level 3 guarantee on the
   container images; verify with `gh attestation verify oci://… --signer-workflow
   jkreileder/cf-ips-to-hcloud-fw/.github/workflows/docker-build.yaml`
+- **Security:** Enabled GitHub's "require actions to be pinned to a full-length
+  commit SHA" repository policy, previously blocked by the generator's
+  tag-referenced reusable workflows
+- Maintenance: dependency and CI-tooling updates, and test-result publishing no
+  longer reports failures for runs superseded by a newer push
 
 ## [v1.3.1] – 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.3.1
+  jkreileder/cf-ips-to-hcloud-fw:1.3.2
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -161,7 +161,7 @@ command override is needed:
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
   -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
-  jkreileder/cf-ips-to-hcloud-fw:1.3.1
+  jkreileder/cf-ips-to-hcloud-fw:1.3.2
 ```
 
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
@@ -169,7 +169,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.3`: This tag always points to the latest `1.3.x` release.
-- `1.3.1`: This tag points to the specific `1.3.1` release.
+- `1.3.2`: This tag points to the specific `1.3.2` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -221,7 +221,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.3.1
+              image: jkreileder/cf-ips-to-hcloud-fw:1.3.2
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false
@@ -248,7 +248,7 @@ falls back to these variables:
 ```yaml
 containers:
   - name: cf-ips-to-hcloud-fw
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.1
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.2
     env:
       - name: HCLOUD_TOKEN
         valueFrom:
@@ -451,7 +451,7 @@ service that uses the image's default one-shot entrypoint:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.1
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.2
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
 ```
@@ -471,7 +471,7 @@ the `docker compose run` line above, or the override makes the run never exit:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.1
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.2
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
     # Re-run every 24h (86400s) inside one container instead of a scheduler.
@@ -514,7 +514,7 @@ For v1.3.1 and earlier the signer workflow was `python-package.yaml` (Python) or
 
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.3.1
+VERSION=1.3.2
 
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
@@ -543,7 +543,7 @@ Build provenance:
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
 IMAGE_REPO=docker.io/jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.3.1
+VERSION=1.3.2
 IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 
 # Verifying build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.3.2.dev1"
+version = "1.3.2"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.3.2.dev1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Release v1.3.2. Bumps the version, finalizes the changelog, and updates the pinned version in docs — the README verification instructions now match what this release's artifacts are actually signed with (the reusable-workflow signers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Released version 1.3.2.

* **Documentation**
  * Updated Docker, Kubernetes, Compose, and verification examples to reference version 1.3.2.
  * Updated the bug report template’s example version.

* **Changelog**
  * Documented CI security and maintenance updates, including artifact attestations and stronger action pinning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->