### PR TITLE
ci(rescan): allow public.ecr.aws for Scout base-image pull

### DIFF
--- a/.github/workflows/rescan.yaml
+++ b/.github/workflows/rescan.yaml
@@ -34,12 +34,14 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: block
-          # Subset of the docker.yaml allowlist: Docker Hub pulls, the Scout
-          # API/CLI and its two d*.cloudfront.net vulnerability-data CDN
-          # distributions, the Grype installer (raw.githubusercontent.com) and
-          # binary (GitHub releases) and its DB, and the SARIF upload. If
-          # Docker or Anchore rotate hosts, update the names from the
-          # harden-runner insights of the failing run.
+          # Subset of the docker.yaml allowlist: Docker Hub pulls, the base
+          # image registry (Scout pulls public.ecr.aws/docker/library/python
+          # for its base-image comparison), the Scout API/CLI and its two
+          # d*.cloudfront.net vulnerability-data CDN distributions, the Grype
+          # installer (raw.githubusercontent.com) and binary (GitHub releases)
+          # and its DB, and the SARIF upload. If Docker or Anchore rotate
+          # hosts, update the names from the harden-runner insights of the
+          # failing run.
           allowed-endpoints: >
             api.dso.docker.com:443
             api.github.com:443
@@ -56,6 +58,7 @@ jobs:
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
+            public.ecr.aws:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443
             registry.scout.docker.com:443


### PR DESCRIPTION
## Summary

The daily rescan run ([31674923038](https://github.com/jkreileder/cf-ips-to-hcloud-fw/actions/runs/31674923038))
was green, but Harden-Runner blocked the Docker Scout base-image pull. The
post-step DNS trace shows the scout-action process dropped on an endpoint
outside the allowlist:

```
[dns-request-dropped] pid=2330 exe=.../docker-scout-action_linux_amd64
                      domain=public.ecr.aws. matchedPolicy=NONE
```

That lines up sub-second with the step's own `...Pulling` (06:44:01.28) →
`✗ Pull failed` (06:44:05.49). `public.ecr.aws` was the only `NONE` in the run;
every other host matched `EXACT_DOMAIN` or `WILDCARD_DOMAIN`.

The Dockerfile sources both base images from `public.ecr.aws`, so Scout pulls
the base image to compare against. `docker-build.yaml` already allows the host;
`rescan.yaml` — written as a subset of that allowlist — missed it. This adds the
entry and updates the comment above it, which enumerates what the list covers.

Scan findings were unaffected in that run: Scout read the SBOM from the
attestation and identified the base image (`f2186fc449b8`) from provenance
rather than from the pull, reporting `0C 0H 0M 0L`. The value of the fix is
removing a blocked-egress event and a spurious failure, so a stray `NONE` in a
hardened workflow doesn't mask the next real block.

Considered switching the base images back to Docker Hub instead (whose hosts are
already allowed), but that reverses the deliberate ECR Public rate-limit
mitigation noted in 12b2c9c and changes the released image's base registry — a
much larger lever than the one-line allowlist drift warrants.

## Security

No token, secret, or firewall-rule changes. This widens the rescan job's
Harden-Runner egress allowlist by one host, `public.ecr.aws:443`, which
`docker-build.yaml` already permits under the same `egress-policy: block`.

## Testing

`make check` — 75 passed, 100% coverage. Pre-commit ran `actionlint` and
`zizmor` over the changed workflow; both passed. Since `rescan.yaml` has
`workflow_dispatch`, the fix can be confirmed after merge by triggering a run
and checking that the Scout step no longer logs `Pull failed` and that no
`matchedPolicy=NONE` remains in the trace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to allow required access to public container image resources.
  * Added documentation clarifying the access used for base-image comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->