### PR TITLE
ci(release): attach the signed attestation bundle to releases

### DIFF
--- a/.github/workflows/build-and-attest-dist.yaml
+++ b/.github/workflows/build-and-attest-dist.yaml
@@ -163,14 +163,24 @@ jobs:
       # check can see the provenance, which it only detects via the
       # `.intoto.jsonl` asset name (ossf/scorecard#4667).
       #
-      # `jq -c .` normalizes each bundle to one line regardless of how many
-      # subjects a bundle covers, yielding the same JSON-lines-of-Sigstore-
-      # bundles file (and name) slsa-github-generator published up to v1.3.1.
+      # actions/attest writes one Sigstore bundle per `bundle-path` file, so
+      # `jq -c .` yields the same JSON-lines-of-Sigstore-bundles file (and name)
+      # slsa-github-generator published up to v1.3.1.
+      #
+      # The assertion guards against a future actions/attest release changing
+      # that layout: Scorecard accepts the asset on its name alone, so a
+      # malformed bundle would ship silently and only break the documented
+      # `gh attestation verify --bundle` path.
       - name: Assemble the attestation bundle
         env:
           SBOM_BUNDLE: ${{ steps.attest-sbom.outputs.bundle-path }}
           PROVENANCE_BUNDLE: ${{ steps.attest-provenance.outputs.bundle-path }}
-        run: jq -c . "$PROVENANCE_BUNDLE" "$SBOM_BUNDLE" > multiple.intoto.jsonl
+        run: |
+          jq -c . "$PROVENANCE_BUNDLE" "$SBOM_BUNDLE" > multiple.intoto.jsonl
+          jq -se 'length == 2
+            and all(.[]; .mediaType
+              | startswith("application/vnd.dev.sigstore.bundle"))' \
+            multiple.intoto.jsonl > /dev/null
 
       - name: Store the attestation bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build-and-attest-dist.yaml
+++ b/.github/workflows/build-and-attest-dist.yaml
@@ -140,6 +140,7 @@ jobs:
           path: sbom
 
       - name: Generate SBOM attestation
+        id: attest-sbom
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: |
@@ -148,8 +149,32 @@ jobs:
           sbom-path: sbom/sbom-python.spdx.json
 
       - name: Generate artifact attestation
+        id: attest-provenance
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: |
             dist/*.whl
             dist/*.tar.gz
+
+      # The attestations above live in GitHub's attestation API, which needs
+      # network access to query. Ship the signed bundles as a release asset too
+      # so the artifacts can be verified offline (`gh attestation verify
+      # --bundle`, see README.md) — and so OpenSSF Scorecard's Signed-Releases
+      # check can see the provenance, which it only detects via the
+      # `.intoto.jsonl` asset name (ossf/scorecard#4667).
+      #
+      # `jq -c .` normalizes each bundle to one line regardless of how many
+      # subjects a bundle covers, yielding the same JSON-lines-of-Sigstore-
+      # bundles file (and name) slsa-github-generator published up to v1.3.1.
+      - name: Assemble the attestation bundle
+        env:
+          SBOM_BUNDLE: ${{ steps.attest-sbom.outputs.bundle-path }}
+          PROVENANCE_BUNDLE: ${{ steps.attest-provenance.outputs.bundle-path }}
+        run: jq -c . "$PROVENANCE_BUNDLE" "$SBOM_BUNDLE" > multiple.intoto.jsonl
+
+      - name: Store the attestation bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: attestation-bundle
+          path: multiple.intoto.jsonl
+          retention-days: 14

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -468,11 +468,20 @@ jobs:
           name: python-package-distributions
           path: dist
 
+      # Signed provenance/SBOM bundles for the artifacts below, so they can be
+      # verified without querying GitHub's attestation API. See the assembly
+      # step in build-and-attest-dist.yaml.
+      - name: Download the attestation bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: attestation-bundle
+          path: attestation
+
       - name: Upload distribution packages to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: >-
           gh release upload
-          "$TAG" dist/**
+          "$TAG" dist/** attestation/multiple.intoto.jsonl
           --repo '${{ github.repository }}'

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
 # Add --format json --jq '.[].verificationResult.statement.predicate' to also output the SBOM
 ```
 
-The commands above query GitHub's attestation API. Releases from v1.3.2 on also ship the
+The commands above query GitHub's attestation API. Releases from v1.3.3 on also ship the
 signed bundles as a `multiple.intoto.jsonl` release asset, covering both the wheel and the
 sdist, so you can verify from disk instead:
 
@@ -552,6 +552,11 @@ gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
 This still fetches the Sigstore trust root. For fully offline verification, capture it
 beforehand with `gh attestation trusted-root > trusted_root.jsonl` and pass
 `--custom-trusted-root trusted_root.jsonl`.
+
+v1.3.2 is the one release without a bundle asset — it was published between the
+`slsa-github-generator` removal and this change, and immutable releases prevent adding one
+after the fact. Verify it with the API-based commands above, or fetch its bundles yourself
+with `gh attestation download`.
 
 ### Verifying Docker Images
 

--- a/README.md
+++ b/README.md
@@ -508,7 +508,11 @@ the build and the attestation signing run inside dedicated reusable workflows
 (`build-and-attest-dist.yaml` for the Python distributions, `docker-build.yaml` for
 the container images), which the `--signer-workflow` checks below pin.
 For v1.3.1 and earlier the signer workflow was `python-package.yaml` (Python) or
-`docker.yaml` (Docker) — substitute those paths when verifying older artifacts.
+`docker.yaml` (Docker) — substitute those paths when verifying older artifacts. Those
+releases also carry a `multiple.intoto.jsonl` asset, but it was produced by
+[slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) and is
+verified with [slsa-verifier](https://github.com/slsa-framework/slsa-verifier) rather than
+with the `gh attestation verify --bundle` command shown below.
 
 ### Verifying Python Wheels and Source Code
 
@@ -531,6 +535,23 @@ gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
   --predicate-type https://spdx.dev/Document/v2.3
 # Add --format json --jq '.[].verificationResult.statement.predicate' to also output the SBOM
 ```
+
+The commands above query GitHub's attestation API. Releases from v1.3.2 on also ship the
+signed bundles as a `multiple.intoto.jsonl` release asset, covering both the wheel and the
+sdist, so you can verify from disk instead:
+
+```shell
+gh release download v$VERSION --repo $GH_REPO --pattern multiple.intoto.jsonl
+
+gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
+  --repo $GH_REPO \
+  --bundle multiple.intoto.jsonl \
+  --signer-workflow $GH_REPO/.github/workflows/build-and-attest-dist.yaml@refs/tags/v$VERSION
+```
+
+This still fetches the Sigstore trust root. For fully offline verification, capture it
+beforehand with `gh attestation trusted-root > trusted_root.jsonl` and pass
+`--custom-trusted-root trusted_root.jsonl`.
 
 ### Verifying Docker Images
 


### PR DESCRIPTION
## Summary

Removing `slsa-github-generator` also removed the `multiple.intoto.jsonl` release
asset. The provenance itself is unaffected — `actions/attest` publishes it to GitHub's
attestation API, and binding the signer to a reusable workflow made it stronger — but the
signed bundles became reachable only over the network.

This assembles the SBOM and provenance bundles into `multiple.intoto.jsonl` and attaches
it to the release again:

- `build-and-attest-dist.yaml` normalizes both bundles to JSON lines (`jq -c .`), asserts
  the result is two Sigstore bundles, and uploads it as a workflow artifact.
- `python-package.yaml` downloads that artifact and attaches it alongside the dists.
- `README.md` documents verification from disk via `gh attestation verify --bundle`,
  plus `--custom-trusted-root` for fully offline use.

Two motivations:

1. **Offline verification.** Verified locally against the v1.3.2 artifacts (using bundles
   from `gh attestation download`): a single bundle file covers both the wheel and the
   sdist, and it passes together with `--signer-workflow`.
2. **OpenSSF Scorecard.** The `Signed-Releases` check detects provenance solely by the
   `.intoto.jsonl` asset name and is blind to the attestation API
   (ossf/scorecard#4667). Without an asset the check would decay by two points per
   release (8 → 6 → 4 → 2 → 0), since provenance scores 10 and signature-only scores 8,
   averaged over the last five releases.

The file keeps the format and name it had through v1.3.1 (JSON lines of Sigstore
bundles), but the predicate is now `slsa.dev/provenance/v1` rather than v0.2, so it is
verified with `gh` rather than `slsa-verifier`. The README notes this for older releases.

The assertion in the assemble step exists because Scorecard reads only the asset name — a
malformed bundle would score full marks while silently breaking the documented
`gh attestation verify --bundle` path.

### v1.3.2 cannot be backfilled

v1.3.2 was published between the generator removal and this change, and immutable
releases are enabled, so no asset can be added to it. It stays a 0 in the check's
five-release window: the score holds at 8 through v1.3.6 and returns to 10 at v1.3.7,
when v1.3.2 rolls out of the window. The README says which release the asset starts at
and how to verify v1.3.2.

Attaching assets from CI is unaffected by immutability — the workflow uploads to the
draft release, which is how v1.3.2's own dists got attached, and immutability locks at
publish.

## Security

No token, secret, or firewall-rule impact. The attestation bundle is signed public
metadata. The privileged `attest-dist` job keeps `contents: read` — the new asset reaches
the release through the existing `upload-dist-to-github-release` job, which already holds
`contents: write`. No harden-runner egress changes were needed.

## Testing

`make check` — 75 passed, 100% coverage. `prek run` over the changed files passes,
including actionlint and zizmor. Offline verification was confirmed end to end against
the published v1.3.2 wheel and sdist, both with and without `--signer-workflow`. The
assemble-step assertion was exercised locally: it accepts two bundles and rejects both an
array-of-bundles layout and a wrong bundle count.