### PR TITLE
build(docker): switch python base images back to Docker Hub

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -77,7 +77,6 @@ jobs:
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
-            public.ecr.aws:443
             pypi.org:443
             quay.io:443
             raw.githubusercontent.com:443

--- a/.github/workflows/rescan.yaml
+++ b/.github/workflows/rescan.yaml
@@ -34,9 +34,9 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: block
-          # Subset of the docker.yaml allowlist: Docker Hub pulls, the base
-          # image registry (Scout pulls public.ecr.aws/docker/library/python
-          # for its base-image comparison), the Scout API/CLI and its two
+          # Subset of the docker.yaml allowlist: Docker Hub pulls (including
+          # the docker.io/library/python base image Scout fetches for its
+          # base-image comparison), the Scout API/CLI and its two
           # d*.cloudfront.net vulnerability-data CDN distributions, the Grype
           # installer (raw.githubusercontent.com) and binary (GitHub releases)
           # and its DB, and the SARIF upload. If Docker or Anchore rotate
@@ -58,7 +58,6 @@ jobs:
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
-            public.ecr.aws:443
             raw.githubusercontent.com:443
             registry-1.docker.io:443
             registry.scout.docker.com:443

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [v1.3.3] – Unreleased
 
 - Start new development cycle
+- Switched the python base images from the `public.ecr.aws` mirror back to
+  Docker Hub (`docker.io/library/python`): GitHub-hosted runners now ship an
+  embedded rate-limit-free Docker Hub pull token, which the build already
+  relies on for the uv/binfmt/buildkit pulls, and the ECR mirror was lagging
+  behind Docker Hub on tag updates
 
 ## [v1.3.2] – 2026-08-12
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM --platform=$BUILDPLATFORM docker.io/astral/uv:0.12.3-python3.14-trixie@sha256:0d7d613acc4bdc9dae1fabd67d30b94887aeab61e215d4a286ce1304a5b90ecf AS uv-tools-trixie
 FROM docker.io/astral/uv:0.12.3-python3.14-alpine3.23@sha256:8caaf73b05ffd22c8789b2dc7c93849422225e9f9942b4f373ea5c7d2543a7bb AS uv-tools-alpine
 
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/python:3.14.7-trixie@sha256:2726708dbfe314177a32630382a594ef58a1628fa482ba77debff710ef71a437 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/python:3.14.7-trixie@sha256:2726708dbfe314177a32630382a594ef58a1628fa482ba77debff710ef71a437 AS builder
 
 WORKDIR /usr/src/app
 
@@ -34,7 +34,7 @@ RUN --mount=type=bind,from=uv-tools-trixie,source=/usr/local/bin/uv,target=/usr/
 EOF
 
 
-FROM public.ecr.aws/docker/library/python:3.14.7-alpine3.24@sha256:f2186fc449b8f7aa5897b542777427a21dc77864f271cf4d1646361cf681c2b9 AS final-image
+FROM docker.io/library/python:3.14.7-alpine3.24@sha256:05b2b8b732ecd268fee8727a369f936f022d1321b59befd13c30ede22769dcdc AS final-image
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Summary

Moves the python base images from the `public.ecr.aws/docker/library` mirror back to
`docker.io/library/python`, and drops `public.ecr.aws` from the harden-runner egress
allowlists in `docker-build.yaml` and `rescan.yaml` (reverting the special case from #1432).

Why this is safe now: GitHub-hosted runners ship an embedded rate-limit-free Docker Hub
pull token in the default docker config, and `docker-build.yaml` is already engineered
around it — no global Hub login before the build, push credentials scoped to buildx via
`login-action`'s `scope` input — so the uv, binfmt, and buildkit pulls have been riding
that token all along, including on fork PR and Dependabot runs. The shared-runner-IP
anonymous rate limits that forced the ECR move in #1281 no longer apply to these pulls.
Scout's daily base-image comparison in `rescan.yaml` authenticates via its action inputs,
so its single pull per day is unaffected.

Bonus found while repinning: the ECR mirror lags Docker Hub — the `3.14.7-alpine3.24` tag
on Docker Hub points at a newer digest (`05b2b8b7…`) than the ECR pin (`f2186fc4…`), so
this also picks up the current image. The trixie digest is identical on both registries.
Renovate keeps pinning digests as before (the dockerfile manager is registry-agnostic),
and the uv provenance-verify step is unaffected (its grep targets `docker.io/astral/uv`).

## Security

No token or firewall-rule impact. Slightly smaller CI egress allowlists (one registry
host removed from two workflows). Base-image provenance posture is unchanged: Docker
Official Image provenance is unsigned on both registries, so the signed-provenance
verification remains uv-only.

## Testing

`make check` — 75 passed, 100% coverage. `prek run` on the changed files — all hooks
pass (incl. actionlint and zizmor on the workflow edits). Verified the pinned digests
resolve on Docker Hub via the registry API.