### PR TITLE
docs(readme): correct the SBOM attestation coverage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,8 @@ gh attestation verify cf_ips_to_hcloud_fw-$VERSION.tar.gz \
   --repo $GH_REPO \
   --signer-workflow $GH_REPO/.github/workflows/build-and-attest-dist.yaml@refs/tags/v$VERSION
 
-# Verifying and showing SBOM (only available for the the wheel)
+# Verifying and showing the SBOM (one attestation covers both distributions,
+# so either file below verifies against it)
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
   --repo $GH_REPO \
   --signer-workflow $GH_REPO/.github/workflows/build-and-attest-dist.yaml@refs/tags/v$VERSION \


### PR DESCRIPTION
## Summary

The SBOM verification example claimed the SBOM is "only available for the the wheel".
That is not the case: `build-and-attest-dist.yaml` passes both `dist/*.whl` and
`dist/*.tar.gz` as `subject-path`, so a single SPDX attestation lists both distributions
as subjects and either file verifies against it.

Corrects the note accordingly and drops the doubled article in the same comment.

Verified two ways rather than reading the workflow alone:

- against the published v1.3.2 attestation via the API — `gh attestation verify` on the
  **sdist** with `--predicate-type https://spdx.dev/Document/v2.3` succeeds and reports
  both the wheel and the sdist as subjects
- against the bundle from the latest `main` build (run 31681251876), where the SBOM line
  likewise carries both subjects

## Security

None. Documentation only; no change to what is attested or how it is verified.

## Testing

`prek run --files README.md` passes, including markdownlint. The commands quoted in the
section were executed against the published v1.3.2 artifacts as described above.