### PR TITLE
chore(release): v1.3.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ debug logs).
 
 **Environment**<!-- markdownlint-disable-line MD036 -->
 
-- cf-ips-to-hcloud-fw version: [e.g. 1.3.2]
+- cf-ips-to-hcloud-fw version: [e.g. 1.3.3]
 - Deployment method: [e.g. Docker, Python module]
 - If Python module, Python version: [e.g. 3.14]
 - If Python module, OS: [e.g. macOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,19 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.3.3] – Unreleased
+## [v1.3.3] – 2026-08-13
 
-- Start new development cycle
 - Switched the python base images from the `public.ecr.aws` mirror back to
   Docker Hub (`docker.io/library/python`): GitHub-hosted runners now ship an
   embedded rate-limit-free Docker Hub pull token, which the build already
   relies on for the uv/binfmt/buildkit pulls, and the ECR mirror was lagging
-  behind Docker Hub on tag updates
+  behind Docker Hub on tag updates — this release's alpine base picks up the
+  newer digest the mirror was missing
+- Releases attach the signed attestation bundle (`multiple.intoto.jsonl`,
+  covering the wheel and sdist) as a release asset again, restoring offline
+  verification with `gh attestation verify --bundle` (see README.md); the
+  bundles now carry `slsa.dev/provenance/v1` predicates and verify with `gh`
+  rather than `slsa-verifier`
 
 ## [v1.3.2] – 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.3.2
+  jkreileder/cf-ips-to-hcloud-fw:1.3.3
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -161,7 +161,7 @@ command override is needed:
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
   -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
-  jkreileder/cf-ips-to-hcloud-fw:1.3.2
+  jkreileder/cf-ips-to-hcloud-fw:1.3.3
 ```
 
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
@@ -169,7 +169,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.3`: This tag always points to the latest `1.3.x` release.
-- `1.3.2`: This tag points to the specific `1.3.2` release.
+- `1.3.3`: This tag points to the specific `1.3.3` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -221,7 +221,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.3.2
+              image: jkreileder/cf-ips-to-hcloud-fw:1.3.3
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false
@@ -248,7 +248,7 @@ falls back to these variables:
 ```yaml
 containers:
   - name: cf-ips-to-hcloud-fw
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.2
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.3
     env:
       - name: HCLOUD_TOKEN
         valueFrom:
@@ -451,7 +451,7 @@ service that uses the image's default one-shot entrypoint:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.2
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.3
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
 ```
@@ -471,7 +471,7 @@ the `docker compose run` line above, or the override makes the run never exit:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.2
+    image: jkreileder/cf-ips-to-hcloud-fw:1.3.3
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
     # Re-run every 24h (86400s) inside one container instead of a scheduler.
@@ -518,7 +518,7 @@ with the `gh attestation verify --bundle` command shown below.
 
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.3.2
+VERSION=1.3.3
 
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
@@ -570,7 +570,7 @@ Build provenance:
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
 IMAGE_REPO=docker.io/jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.3.2
+VERSION=1.3.3
 IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 
 # Verifying build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.3.3.dev1"
+version = "1.3.3"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.3.3.dev1"
+version = "1.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
## Summary

Release v1.3.3: bumps the version (pyproject + uv.lock), finalizes the changelog, and
updates the pinned version references in `README.md` and the bug-report template. Ships
the python base-image switch back to Docker Hub (#1434) and the attestation-bundle
release asset (#1433).

Releasing now also unblocks Docker Scout's base-image analysis: the released `:1` image
still records the `public.ecr.aws` python base, which the harden-runner egress policy no
longer allows since #1434. Once `:1` rolls onto the `docker.io` base, Scout stops needing
ECR in both `docker-build.yaml` and `rescan.yaml`.

## Security

None beyond the changes already merged; this PR only bumps versions and docs.

## Testing

`make lint`, `make test` (75 passed, 100% coverage), and `make build` (wheel + sdist for
1.3.3) all pass locally.