### PR TITLE
chore: start new development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- markdownlint-disable MD024 -->
 
+## [v1.3.4] – Unreleased
+
+- Start new development cycle
+
 ## [v1.3.3] – 2026-08-13
 
 - Switched the python base images from the `public.ecr.aws` mirror back to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.3.3"
+version = "1.3.4.dev1"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.3.3"
+version = "1.3.4.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
## Summary

Begin v1.3.4 development: bump the version to 1.3.4.dev1 (pyproject + uv.lock) and add a
fresh Unreleased heading to the changelog, following the v1.3.3 release.

## Testing

`uv lock` regenerated cleanly; no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Started the next development cycle with version 1.3.4.dev1.
  * Added an unreleased 1.3.4 entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->