### PR TITLE
fix(config): redact YAML parse errors that echo the API token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   a digest against the matched version's original release date, so an action tag
   force-pushed to new commits clears the check immediately. Image digests still
   automerge, since Docker Hub's `tag_last_pushed` restarts the hold
+- Config file YAML parse errors no longer echo the offending source line into
+  the log. PyYAML's error formatting embeds a snippet of the file, which put the
+  raw Hetzner API token into the log stream whenever the syntax error sat on or
+  next to the `token:` line (an unterminated quote, a stray tab, an unclosed
+  flow mapping). Errors now report the parser's own description plus the line
+  and column, matching the redaction already applied to config validation errors
 
 ## [v1.3.3] – 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@
   a digest against the matched version's original release date, so an action tag
   force-pushed to new commits clears the check immediately. Image digests still
   automerge, since Docker Hub's `tag_last_pushed` restarts the hold
-- Config file YAML parse errors no longer echo the offending source line into
-  the log. PyYAML's error formatting embeds a snippet of the file, which put the
-  raw Hetzner API token into the log stream whenever the syntax error sat on or
-  next to the `token:` line (an unterminated quote, a stray tab, an unclosed
-  flow mapping). Errors now report the parser's own description plus the line
-  and column, matching the redaction already applied to config validation errors
+- Config file YAML parse errors no longer echo any part of the file into the
+  log. PyYAML's error formatting embeds a snippet of the offending source line,
+  which put the raw Hetzner API token into the log stream whenever the syntax
+  error sat on or next to the `token:` line (an unterminated quote, a stray tab,
+  an unclosed flow mapping); PyYAML also interpolates alias, anchor, and tag
+  names into its own error text, so a stray `*` or `&` before the value leaked
+  it too. Errors now report only the error type plus the line and column,
+  matching the redaction already applied to config validation errors
 
 ## [v1.3.3] – 2026-08-13
 

--- a/src/cf_ips_to_hcloud_fw/config.py
+++ b/src/cf_ips_to_hcloud_fw/config.py
@@ -60,11 +60,17 @@ def _describe_yaml_error(e: yaml.YAMLError) -> str:
     the ``token:`` line - an unterminated quote, a stray tab, an unclosed flow
     mapping - that snippet writes the raw Hetzner API token straight into the
     log stream, which is typically readable by far more principals than the
-    config file itself. PyYAML's ``context``/``problem`` strings are static
-    descriptions that interpolate at most a single offending character, and the
-    marks carry line/column numbers, so both are safe to report; the snippets
-    are not. This mirrors the ``include_input=False`` redaction already applied
-    to the Pydantic validation errors below.
+    config file itself.
+
+    The parser's own ``context``/``problem`` descriptions are no safer: PyYAML
+    interpolates source-derived identifiers into some of them, so a stray ``*``
+    or ``&`` in front of the value - a mangled template render, a bad paste -
+    makes the token an alias, anchor, or tag handle that lands in the message
+    verbatim ("found undefined alias '<token>'"). Which strings do that varies
+    by PyYAML version, so rather than auditing them, report only the error type
+    and position: neither can carry file contents at any version. This mirrors
+    the ``include_input=False`` redaction already applied to the Pydantic
+    validation errors below.
 
     Args:
         e: Exception raised while parsing the config file.
@@ -72,11 +78,6 @@ def _describe_yaml_error(e: yaml.YAMLError) -> str:
     Returns:
         str: What failed and where, free of file contents.
     """
-    detail = ": ".join(
-        str(part)
-        for part in (getattr(e, "context", None), getattr(e, "problem", None))
-        if part
-    )
     # ReaderError and bare YAMLErrors carry no marks; fall back to the position
     # being unknown rather than raising while handling an error.
     mark = getattr(e, "problem_mark", None) or getattr(e, "context_mark", None)
@@ -85,7 +86,7 @@ def _describe_yaml_error(e: yaml.YAMLError) -> str:
         if mark is not None
         else ""
     )
-    return f"{detail or type(e).__name__}{location}"
+    return f"{type(e).__name__}{location}"
 
 
 def _read_config(config_file: str) -> list[Project]:

--- a/src/cf_ips_to_hcloud_fw/config.py
+++ b/src/cf_ips_to_hcloud_fw/config.py
@@ -52,6 +52,42 @@ def _validate_config_permissions(config_file: str) -> None:
         )
 
 
+def _describe_yaml_error(e: yaml.YAMLError) -> str:
+    """Summarize a YAML parse failure without echoing the file's contents.
+
+    ``yaml.MarkedYAMLError.__str__`` embeds ``Mark.get_snippet()``, a verbatim
+    copy of the offending source line. When the syntax error sits on or next to
+    the ``token:`` line - an unterminated quote, a stray tab, an unclosed flow
+    mapping - that snippet writes the raw Hetzner API token straight into the
+    log stream, which is typically readable by far more principals than the
+    config file itself. PyYAML's ``context``/``problem`` strings are static
+    descriptions that interpolate at most a single offending character, and the
+    marks carry line/column numbers, so both are safe to report; the snippets
+    are not. This mirrors the ``include_input=False`` redaction already applied
+    to the Pydantic validation errors below.
+
+    Args:
+        e: Exception raised while parsing the config file.
+
+    Returns:
+        str: What failed and where, free of file contents.
+    """
+    detail = ": ".join(
+        str(part)
+        for part in (getattr(e, "context", None), getattr(e, "problem", None))
+        if part
+    )
+    # ReaderError and bare YAMLErrors carry no marks; fall back to the position
+    # being unknown rather than raising while handling an error.
+    mark = getattr(e, "problem_mark", None) or getattr(e, "context_mark", None)
+    location = (
+        f" at line {mark.line + 1}, column {mark.column + 1}"
+        if mark is not None
+        else ""
+    )
+    return f"{detail or type(e).__name__}{location}"
+
+
 def _read_config(config_file: str) -> list[Project]:
     """Load and validate project definitions from a YAML file.
 
@@ -73,7 +109,9 @@ def _read_config(config_file: str) -> list[Project]:
     except PermissionError:
         log_error_and_exit(f"Config file {config_file!r} is unreadable.")
     except yaml.YAMLError as e:
-        log_error_and_exit(f"Error reading config file {config_file!r}: {e}")
+        log_error_and_exit(
+            f"Error reading config file {config_file!r}: {_describe_yaml_error(e)}"
+        )
 
     try:
         projects = TypeAdapter(list[Project]).validate_python(config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
+import yaml
 from pydantic import SecretStr
 
 from cf_ips_to_hcloud_fw.config import (
@@ -213,6 +214,63 @@ def test_read_config_broken_yaml(mock_logging: MagicMock) -> None:
     assert e.value.code == 1
     mock_logging.assert_called_once()
     assert "Error reading config file 'config.yaml': " in mock_logging.call_args[0][0]
+
+
+# Malformations whose PyYAML error marks land on the token line, so that
+# `MarkedYAMLError.__str__` would splice the token into the message. Verified
+# against PyYAML: each of these leaks the raw value when the exception is
+# formatted with `str(e)`.
+LEAKY_YAML = {
+    "unterminated-quote": (
+        '- token: "SUPER_SECRET_TOKEN_VALUE\n  firewalls:\n    - fw-1\n'
+    ),
+    "tab-after-key": "- token:\tSUPER_SECRET_TOKEN_VALUE\n  firewalls: [fw-1]\n",
+    "unclosed-flow-mapping": "- {token: SUPER_SECRET_TOKEN_VALUE, firewalls: [fw-1]\n",
+}
+
+
+@pytest.mark.parametrize("yaml_source", LEAKY_YAML.values(), ids=LEAKY_YAML.keys())
+@patch("cf_ips_to_hcloud_fw.config.os.name", "nt")
+@patch("logging.error")
+def test_read_config_yaml_error_redacts_secret_value(
+    mock_logging: MagicMock,
+    yaml_source: str,
+) -> None:
+    """YAML parse errors must not echo the source line holding the token."""
+    with (
+        patch("builtins.open", mock_open(read_data=yaml_source)),
+        pytest.raises(SystemExit) as e,
+    ):
+        _read_config("config.yaml")
+
+    assert e.value.code == 1
+    mock_logging.assert_called_once()
+    error_msg = mock_logging.call_args[0][0]
+    assert "Error reading config file 'config.yaml': " in error_msg
+    assert "SUPER_SECRET_TOKEN_VALUE" not in error_msg
+    # The operator still gets an actionable message: what broke and where.
+    assert "line " in error_msg
+
+
+@patch("logging.error")
+def test_read_config_yaml_error_without_marks(mock_logging: MagicMock) -> None:
+    """A YAMLError carrying no position marks still logs without raising."""
+    with (
+        patch("builtins.open", mock_open(read_data="- token: token\n")),
+        patch(
+            "cf_ips_to_hcloud_fw.config.yaml.safe_load",
+            side_effect=yaml.YAMLError("bare failure"),
+        ),
+        pytest.raises(SystemExit) as e,
+    ):
+        _read_config("config.yaml")
+
+    assert e.value.code == 1
+    mock_logging.assert_called_once()
+    assert (
+        "Error reading config file 'config.yaml': YAMLError"
+        in mock_logging.call_args[0][0]
+    )
 
 
 @patch(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -216,16 +216,31 @@ def test_read_config_broken_yaml(mock_logging: MagicMock) -> None:
     assert "Error reading config file 'config.yaml': " in mock_logging.call_args[0][0]
 
 
-# Malformations whose PyYAML error marks land on the token line, so that
-# `MarkedYAMLError.__str__` would splice the token into the message. Verified
-# against PyYAML: each of these leaks the raw value when the exception is
-# formatted with `str(e)`.
+# Malformations that put the token into PyYAML's own error output, verified
+# against PyYAML. The first three land the error marks on the token line, so
+# `MarkedYAMLError.__str__` splices in the source snippet. The rest turn the
+# token into an identifier that PyYAML interpolates into `problem` itself, so
+# forwarding the parser's description would leak it even without the snippet.
 LEAKY_YAML = {
     "unterminated-quote": (
         '- token: "SUPER_SECRET_TOKEN_VALUE\n  firewalls:\n    - fw-1\n'
     ),
     "tab-after-key": "- token:\tSUPER_SECRET_TOKEN_VALUE\n  firewalls: [fw-1]\n",
     "unclosed-flow-mapping": "- {token: SUPER_SECRET_TOKEN_VALUE, firewalls: [fw-1]\n",
+    "undefined-alias": "- token: *SUPER_SECRET_TOKEN_VALUE\n  firewalls: [fw-1]\n",
+    "duplicate-anchor": (
+        "- token: &SUPER_SECRET_TOKEN_VALUE t1\n"
+        "  firewalls: [fw-1]\n"
+        "- token: &SUPER_SECRET_TOKEN_VALUE t2\n"
+        "  firewalls: [fw-2]\n"
+    ),
+    "duplicate-tag-handle": (
+        "%TAG !SUPER_SECRET_TOKEN_VALUE! tag:example.com,2026:\n"
+        "%TAG !SUPER_SECRET_TOKEN_VALUE! tag:example.com,2027:\n"
+        "---\n"
+        "- token: t\n"
+        "  firewalls: [fw-1]\n"
+    ),
 }
 
 
@@ -236,7 +251,7 @@ def test_read_config_yaml_error_redacts_secret_value(
     mock_logging: MagicMock,
     yaml_source: str,
 ) -> None:
-    """YAML parse errors must not echo the source line holding the token."""
+    """YAML parse errors must not echo any part of the file holding the token."""
     with (
         patch("builtins.open", mock_open(read_data=yaml_source)),
         pytest.raises(SystemExit) as e,


### PR DESCRIPTION
## What

`_read_config` logged `str(e)` for `yaml.YAMLError`. PyYAML's
`MarkedYAMLError.__str__` calls `Mark.get_snippet()`, which emits a verbatim copy of the
offending source line — so a config syntax error on or next to the `token:` line wrote the
raw Hetzner API token into the log stream.

That is the boundary `SecretStr` and the `include_input=False` redaction on the Pydantic
branch (`config.py:81-85`) already defend; the YAML branch just above them was missed.
Logs are typically readable by more principals than the config file itself — a `kubectl
logs` reader without `secrets/get`, or anyone downstream of a log aggregator.

## Reproduced before the fix

Two distinct leak channels, six cases, all now regression tests mirroring the existing
`test_read_config_validation_error_redacts_secret_value`.

**The source snippet**, when the error marks land on the token line:

| Malformation | Leaked via |
| --- | --- |
| `- token: "SUPER_SECRET` (unterminated quote) | `get_snippet()` |
| `- token:<TAB>SUPER_SECRET` (tab after key) | `get_snippet()` |
| `- {token: SUPER_SECRET, firewalls: [fw-1]` (unclosed flow mapping) | `get_snippet()` |

**PyYAML's own error text**, when the token becomes a source-derived identifier — a stray
`*` or `&` from a mangled template render or a bad paste:

| Malformation | Leaked message |
| --- | --- |
| `- token: *SUPER_SECRET` | `found undefined alias 'SUPER_SECRET…'` |
| duplicate `&SUPER_SECRET` anchors | `found duplicate anchor 'SUPER_SECRET…'` |
| duplicate `!SUPER_SECRET!` tag handles | `duplicate tag handle '!SUPER_SECRET…!'` |

The second group was caught by CodeRabbit's review of the first commit (the alias and
anchor cases); the tag-handle `ParserError` turned up while confirming them.

## How

`_describe_yaml_error` reports the exception class name and the mark's line and column,
and nothing else.

An earlier pass forwarded PyYAML's `context`/`problem` descriptions on the grounds that
they only interpolate a single offending character. That audit was wrong — see the second
table. Rather than allowlisting which strings are safe, which varies by PyYAML version,
the helper now emits nothing that originates in the file at all:

```
Error reading config file 'config.yaml': ScannerError at line 1, column 9
Error reading config file 'config.yaml': ComposerError at line 1, column 10
```

The operator has the file, so the position is enough to find the fault.

Marks are read via `getattr` because `ReaderError` and bare `YAMLError`s carry none —
otherwise the redaction would trade a leak for an `AttributeError` while handling an error.
That path is covered too.

## Notes

Found by an agentic SAST run over the repo. `make lint` and `make test` pass; coverage
stays at 100%.
