### PR TITLE
fix(cloudflare): pin the API base URL and check CIDR routability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@
   names into its own error text, so a stray `*` or `&` before the value leaked
   it too. Errors now report only the error type plus the line and column,
   matching the redaction already applied to config validation errors
+- Pinned the Cloudflare API base URL in code. The SDK falls back to the
+  `CLOUDFLARE_BASE_URL` environment variable when no base URL is passed, so
+  anything able to set an env var on the job — a CronJob spec, a compose file, a
+  workflow env block — could point the IP fetch at its own server and dictate
+  what the firewall rules end up allowing. That variable is now inert
+- Cloudflare CIDR responses are checked for routability, not just syntax.
+  Default routes (`0.0.0.0/0`, `::/0`) and unspecified, loopback, link-local,
+  multicast, and private ranges are rejected instead of being written verbatim
+  into firewall rules — a broken or tampered response can no longer widen an
+  allow list. No minimum prefix length is enforced, so a broader aggregate from
+  Cloudflare will not fail the run
 
 ## [v1.3.3] – 2026-08-13
 

--- a/src/cf_ips_to_hcloud_fw/cloudflare.py
+++ b/src/cf_ips_to_hcloud_fw/cloudflare.py
@@ -22,6 +22,14 @@ _NO_AUTH_HEADERS = {
     "X-Auth-User-Service-Key": Omit(),
 }
 
+# Passed explicitly because the SDK otherwise falls back to the
+# CLOUDFLARE_BASE_URL environment variable. The tool never advertised that knob,
+# and it decides where the firewall's entire allow list comes from, so anything
+# able to set an env var on the job - a CronJob spec, a compose file, a workflow
+# env block - could redirect the fetch to its own server. Pinning it here makes
+# the variable inert; the value is the SDK's own default.
+CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4"
+
 
 def cf_ips_list() -> cloudflare.types.ips.IPListResponse | None:
     """Call Cloudflare's `ips.list` endpoint and return the raw response.
@@ -30,7 +38,7 @@ def cf_ips_list() -> cloudflare.types.ips.IPListResponse | None:
         cloudflare.types.ips.IPListResponse | None: Raw API response, or None
         when the SDK returns no payload.
     """
-    cf = cloudflare.Cloudflare()
+    cf = cloudflare.Cloudflare(base_url=CLOUDFLARE_API_BASE_URL)
     try:
         return cf.ips.list(extra_headers=_NO_AUTH_HEADERS)
     except (cloudflare.APIConnectionError, cloudflare.APIStatusError) as e:

--- a/src/cf_ips_to_hcloud_fw/models.py
+++ b/src/cf_ips_to_hcloud_fw/models.py
@@ -3,15 +3,78 @@
 from __future__ import annotations
 
 from ipaddress import IPv4Network, IPv6Network
+from typing import Annotated, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, SecretStr
+
+_Network = TypeVar("_Network", IPv4Network, IPv6Network)
+
+
+def _require_globally_routable(network: _Network) -> _Network:
+    """Reject CIDRs that must never end up in a Cloudflare-only allow rule.
+
+    Parsing only proves a CIDR is well-formed, so a tampered or malfunctioning
+    API response could hand us a range that is syntactically fine and
+    semantically catastrophic: ``0.0.0.0/0`` passes every structural check and
+    would open every marked firewall rule to the whole internet. Cloudflare
+    only ever publishes globally routable unicast space - the live list bottoms
+    out at /13 for IPv4 and /29 for IPv6 - so anything else is a broken payload
+    rather than a range worth syncing.
+
+    Deliberately no minimum prefix length: a floor tight enough to be useful
+    would hard-fail the run if Cloudflare ever published a broader aggregate,
+    turning a hypothetical tampering risk into a real outage with stale rules.
+    ``is_reserved`` is left out for the same reason - for IPv6 it means "outside
+    IANA-allocated space", so an allocation newer than the running Python's
+    tables would be refused, and unallocated space is not routable to an
+    attacker anyway.
+
+    Args:
+        network: A parsed CIDR from the Cloudflare response.
+
+    Returns:
+        The network unchanged, when it is globally routable.
+
+    Raises:
+        ValueError: If the network is a default route or non-global space.
+    """
+    # A default route needs its own test: `IPv4Network("0.0.0.0/0").is_private`
+    # is False, so the flag checks below do not catch it.
+    if network.prefixlen == 0:
+        msg = f"{network} is a default route"
+        raise ValueError(msg)
+
+    disallowed = [
+        name
+        for name, matches in (
+            ("unspecified", network.is_unspecified),
+            ("loopback", network.is_loopback),
+            ("link-local", network.is_link_local),
+            ("multicast", network.is_multicast),
+            ("private", network.is_private),
+        )
+        if matches
+    ]
+    if disallowed:
+        msg = f"{network} is not globally routable ({', '.join(disallowed)})"
+        raise ValueError(msg)
+
+    return network
+
+
+GloballyRoutableIPv4Network = Annotated[
+    IPv4Network, AfterValidator(_require_globally_routable)
+]
+GloballyRoutableIPv6Network = Annotated[
+    IPv6Network, AfterValidator(_require_globally_routable)
+]
 
 
 class CloudflareIPNetworks(BaseModel):
     """Cloudflare CIDRs parsed as IP network objects, used to validate input."""
 
-    ipv4_cidrs: list[IPv4Network]
-    ipv6_cidrs: list[IPv6Network]
+    ipv4_cidrs: list[GloballyRoutableIPv4Network]
+    ipv6_cidrs: list[GloballyRoutableIPv6Network]
 
 
 class CloudflareCIDRs(BaseModel):

--- a/tests/test_cloudflare.py
+++ b/tests/test_cloudflare.py
@@ -25,8 +25,11 @@ def test_cf_ips_list_sends_no_credentials(mock_cloudflare: MagicMock) -> None:
     result = cf_ips_list()
 
     assert result is sentinel
-    # No api_key/api_token/etc. is passed to the client constructor.
-    mock_cloudflare.assert_called_once_with()
+    # No api_key/api_token/etc. is passed to the client constructor, but the
+    # base URL is pinned so CLOUDFLARE_BASE_URL cannot redirect the fetch.
+    mock_cloudflare.assert_called_once_with(
+        base_url="https://api.cloudflare.com/client/v4"
+    )
     _, kwargs = mock_cloudflare.return_value.ips.list.call_args
     headers = kwargs["extra_headers"]
     assert set(headers) == {
@@ -36,6 +39,25 @@ def test_cf_ips_list_sends_no_credentials(mock_cloudflare: MagicMock) -> None:
         "X-Auth-User-Service-Key",
     }
     assert all(isinstance(value, cloudflare.Omit) for value in headers.values())
+
+
+@patch.dict("os.environ", {"CLOUDFLARE_BASE_URL": "http://attacker.example.invalid"})
+def test_cf_ips_list_ignores_base_url_env_var() -> None:
+    """CLOUDFLARE_BASE_URL must not redirect the fetch to another server."""
+    real_client = cloudflare.Cloudflare
+    created: list[cloudflare.Cloudflare] = []
+
+    def build(*, base_url: str) -> MagicMock:
+        # Build a real client so the SDK's own env-var fallback gets its chance,
+        # then hand cf_ips_list a stub so no request is attempted.
+        created.append(real_client(base_url=base_url))
+        return MagicMock()
+
+    with patch("cloudflare.Cloudflare", side_effect=build):
+        cf_ips_list()
+
+    assert len(created) == 1
+    assert str(created[0].base_url) == "https://api.cloudflare.com/client/v4/"
 
 
 @patch("cloudflare.Cloudflare")
@@ -140,6 +162,42 @@ def test_get_cloudflare_cidrs_invalid(mock_logging: MagicMock) -> None:
     """Invalid IP payloads propagate a validation error through log_error_and_exit."""
     with pytest.raises(SystemExit) as e:
         get_cloudflare_cidrs()
+    assert e.value.code == 1
+    mock_logging.assert_called_once()
+    assert "Cloudflare/ips.list didn't validate" in mock_logging.call_args[0][0]
+
+
+@pytest.mark.parametrize(
+    ("ipv4_cidrs", "ipv6_cidrs"),
+    [
+        pytest.param(["0.0.0.0/0"], ["2400:cb00::/32"], id="ipv4-default-route"),
+        pytest.param(["198.27.128.0/21"], ["::/0"], id="ipv6-default-route"),
+        pytest.param(["10.0.0.0/8"], ["2400:cb00::/32"], id="ipv4-private"),
+        pytest.param(["127.0.0.0/8"], ["2400:cb00::/32"], id="ipv4-loopback"),
+        pytest.param(["198.27.128.0/21"], ["fc00::/7"], id="ipv6-unique-local"),
+        pytest.param(["198.27.128.0/21"], ["fe80::/10"], id="ipv6-link-local"),
+    ],
+)
+@patch("logging.error")
+def test_get_cloudflare_cidrs_rejects_unroutable(
+    mock_logging: MagicMock,
+    ipv4_cidrs: list[str],
+    ipv6_cidrs: list[str],
+) -> None:
+    """Syntactically valid but unroutable ranges must never reach a firewall."""
+    response = cloudflare.types.ips.ip_list_response.PublicIPIPs(
+        ipv4_cidrs=ipv4_cidrs,
+        ipv6_cidrs=ipv6_cidrs,
+    )
+    with (
+        patch(
+            "cf_ips_to_hcloud_fw.cloudflare.cf_ips_list",
+            MagicMock(return_value=response),
+        ),
+        pytest.raises(SystemExit) as e,
+    ):
+        get_cloudflare_cidrs()
+
     assert e.value.code == 1
     mock_logging.assert_called_once()
     assert "Cloudflare/ips.list didn't validate" in mock_logging.call_args[0][0]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,81 @@ from __future__ import annotations
 import pytest
 from pydantic import SecretStr, ValidationError
 
-from cf_ips_to_hcloud_fw.models import Project
+from cf_ips_to_hcloud_fw.models import CloudflareIPNetworks, Project
+
+# Every CIDR Cloudflare publishes today, as a guard against the routability
+# check rejecting a real response. The live list bottoms out at /13 for IPv4
+# and /29 for IPv6, which is why no minimum prefix length is enforced.
+PUBLISHED_IPV4_CIDRS = [
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    "131.0.72.0/22",
+]
+PUBLISHED_IPV6_CIDRS = [
+    "2400:cb00::/32",
+    "2606:4700::/32",
+    "2803:f800::/32",
+    "2405:b500::/32",
+    "2405:8100::/32",
+    "2a06:98c0::/29",
+    "2c0f:f248::/32",
+]
+
+
+def test_cloudflare_ip_networks_accepts_published_ranges() -> None:
+    """The published Cloudflare ranges must all pass the routability check."""
+    networks = CloudflareIPNetworks(
+        ipv4_cidrs=PUBLISHED_IPV4_CIDRS,
+        ipv6_cidrs=PUBLISHED_IPV6_CIDRS,
+    )
+    assert len(networks.ipv4_cidrs) == len(PUBLISHED_IPV4_CIDRS)
+    assert len(networks.ipv6_cidrs) == len(PUBLISHED_IPV6_CIDRS)
+
+
+@pytest.mark.parametrize(
+    ("cidr", "reason"),
+    [
+        ("0.0.0.0/0", "default route"),
+        ("10.0.0.0/8", "not globally routable (private)"),
+        ("127.0.0.0/8", "not globally routable"),
+        ("169.254.0.0/16", "not globally routable"),
+        ("224.0.0.0/4", "not globally routable (multicast)"),
+        ("240.0.0.0/4", "not globally routable"),
+    ],
+)
+def test_cloudflare_ip_networks_rejects_unroutable_ipv4(cidr: str, reason: str) -> None:
+    """Unroutable IPv4 ranges are rejected with an explanatory message."""
+    with pytest.raises(ValidationError) as e:
+        CloudflareIPNetworks(ipv4_cidrs=[cidr], ipv6_cidrs=["2400:cb00::/32"])
+    assert reason in str(e.value)
+
+
+@pytest.mark.parametrize(
+    ("cidr", "reason"),
+    [
+        ("::/0", "default route"),
+        ("fc00::/7", "not globally routable (private)"),
+        ("fe80::/10", "not globally routable"),
+        ("ff00::/8", "not globally routable (multicast)"),
+    ],
+)
+def test_cloudflare_ip_networks_rejects_unroutable_ipv6(cidr: str, reason: str) -> None:
+    """Unroutable IPv6 ranges are rejected with an explanatory message."""
+    with pytest.raises(ValidationError) as e:
+        CloudflareIPNetworks(ipv4_cidrs=["198.27.128.0/21"], ipv6_cidrs=[cidr])
+    assert reason in str(e.value)
 
 
 def test_project_valid() -> None:


### PR DESCRIPTION
Two gaps on the same path — what the tool fetches, and what it accepts back before
writing it into a firewall's source list.

## Pin the API base URL

`cloudflare.Cloudflare()` was constructed with no `base_url`, and the SDK falls back to
the `CLOUDFLARE_BASE_URL` environment variable in that case
(`cloudflare/_client.py:405`). The tool never advertised that knob, yet it decides where
the entire allow list comes from — so anything able to set an env var on the job (a
CronJob spec, a compose file, a workflow env block) could point the fetch at its own
server and dictate what the firewalls end up allowing.

Verified before the change:

```
$ CLOUDFLARE_BASE_URL=http://attacker.example.invalid python -c "..."
unpinned: http://attacker.example.invalid
pinned  : https://api.cloudflare.com/client/v4/
```

The pinned value is the SDK's own default, so nothing else changes. The regression test
builds a *real* client under a hostile `CLOUDFLARE_BASE_URL` so the SDK's fallback gets
its chance, then asserts it lost.

## Check CIDR routability, not just syntax

Parsing only proves a CIDR is well-formed. `0.0.0.0/0` parses fine, passes the empty-list
guard added in v1.2.0, and would open every rule marked `__CLOUDFLARE_IPS_*__` to the
whole internet. The check now rejects default routes and unspecified, loopback,
link-local, multicast, and private ranges, at the model where the existing sanity-check
`TypeAdapter` already runs.

**What is deliberately *not* checked**, since a false rejection here means a hard exit and
stale firewall rules — a worse outcome than the risk being mitigated:

- **No minimum prefix length.** The SAST report suggested a /7 and /19 floor; that would
  hard-fail the run if Cloudflare ever published a broader aggregate.
- **No `is_reserved`.** For IPv6 it means "outside IANA-allocated space", so an allocation
  newer than the running Python's tables would be refused. It also caught nothing useful:
  unallocated space isn't routable to an attacker, and for IPv4 the ranges it covers are
  already `is_private`. It did flag `1400:cb00::/32` — a made-up CIDR in an existing test
  fixture — which is what surfaced the brittleness.

Checked against the live API response: all 22 published CIDRs pass, and the list bottoms
out at /13 (IPv4) and /29 (IPv6). Those ranges are now a regression test guarding against
the check rejecting a real payload.

## Notes

Found by an agentic SAST run over the repo; the report rated the CIDR gap CRITICAL on a
TLS-MITM premise, which I'd discount — the realistic value here is robustness against an
upstream API bug, the same instinct as the v1.2.0 empty-list guard. `make lint` and `make
test` pass; coverage stays at 100%.
