### PR TITLE
ci(renovate): stop automerging GitHub Actions digest refreshes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -173,6 +173,17 @@
                 "digest",
                 "pin"
             ]
+        },
+        {
+            "automerge": false,
+            "description": "GitHub Actions digest refreshes are reviewed by hand: minimumReleaseAge cannot hold them back. The github-tags datasource ages a digest against the matched version's original release date, so an action tag force-pushed to new commits clears the 3-day check immediately and would otherwise automerge within hours. Kept in its own group so image digests - where Docker Hub's tag_last_pushed restarts the hold - still automerge.",
+            "groupName": "github-actions-digests",
+            "matchManagers": [
+                "github-actions"
+            ],
+            "matchUpdateTypes": [
+                "digest"
+            ]
         }
     ],
     "semanticCommits": "enabled",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [v1.3.4] – Unreleased
 
 - Start new development cycle
+- GitHub Actions digest refreshes are no longer automerged. The 3-day
+  `minimumReleaseAge` hold cannot gate them — the `github-tags` datasource ages
+  a digest against the matched version's original release date, so an action tag
+  force-pushed to new commits clears the check immediately. Image digests still
+  automerge, since Docker Hub's `tag_last_pushed` restarts the hold
 
 ## [v1.3.3] – 2026-08-13
 


### PR DESCRIPTION
## What

`minimumReleaseAge: "3 days"` (line 66) does not hold back GitHub Actions digest
refreshes, and the blanket `digest`/`pin` automerge rule fires on them immediately. A
compromised upstream action would have landed in CI within hours, with no hold and no
human review.

From Renovate's [minimum-release-age
docs](https://github.com/renovatebot/renovate/blob/main/docs/usage/key-concepts/minimum-release-age.md):

> Datasources whose timestamps reflect when the matched version was first released (such
> as `github-tags` for digest-pinned GitHub Actions) cannot detect re-published content.
> If an existing tag is force-pushed to new commits, the digest update ages against the
> original release date, so it may pass Minimum Release Age immediately.

`internalChecksFilter: strict` only helps if the payload breaks CI, which a targeted
attack would avoid.

## Scope

I checked each update type against the docs' support table rather than blanket-disabling
automerge:

| Path | Gated today? | Change |
| --- | --- | --- |
| GitHub Actions `digest` | no — ages against original release date | **automerge off** |
| Docker Hub image `digest` | yes — `tag_last_pushed` restarts the hold | unchanged |
| GHCR / Quay `digest` | yes — no timestamp, held under default `timestamp-required` | unchanged |
| `pin` / `pinDigest` | no | unchanged — see below |
| pre-commit hooks | — | unchanged |

`pin` and `pinDigest` are deliberately left alone: both freeze what a reference already
resolves to rather than repointing it, so holding them back would only prolong the
less-safe unpinned state. The pre-commit rule is left alone too — the config comment shows
that was a considered decision.

The new rule gets its own `groupName` so a held actions-digest PR doesn't drag the image
digests out of automerge with it.

## Note on the report's suggested fix

The SAST report proposed adding `"minimumReleaseAge": "3 days"` inside the digests rule.
That's a no-op — it's already inherited from line 66, and inheriting it is exactly what
doesn't work here.

## Verification

`renovate-config-validator --strict` passes at 44.17.0, the version pinned in
`.pre-commit-config.yaml`. (A bare `npx renovate` resolves to an older build that rejects
the existing `managerFilePatterns` fields — worth knowing if you validate by hand.)
