### PR TITLE
fix(models): reject CIDR aggregates that subsume reserved space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,15 @@
   anything able to set an env var on the job — a CronJob spec, a compose file, a
   workflow env block — could point the IP fetch at its own server and dictate
   what the firewall rules end up allowing. That variable is now inert
-- Cloudflare CIDR responses are checked for routability, not just syntax.
-  Default routes (`0.0.0.0/0`, `::/0`) and unspecified, loopback, link-local,
-  multicast, and private ranges are rejected instead of being written verbatim
-  into firewall rules — a broken or tampered response can no longer widen an
-  allow list. No minimum prefix length is enforced, so a broader aggregate from
-  Cloudflare will not fail the run
+- Cloudflare CIDR responses are checked for routability, not just syntax. A
+  range is rejected if it overlaps IANA special-purpose space (RFC 1918,
+  loopback, link-local, CGNAT, multicast, reserved, documentation) or is
+  broader than /8 for IPv4 or /16 for IPv6, instead of being written verbatim
+  into firewall rules — so a broken or tampered response can no longer widen an
+  allow list, whether by naming a reserved range outright (`10.0.0.0/8`) or by
+  hiding it inside an aggregate (`0.0.0.0/0`, `128.0.0.0/1`, `8000::/1`). The
+  prefix floors sit far below the /13 and /29 the published list bottoms out
+  at, so a legitimately broader range from Cloudflare will not fail the run
 
 ## [v1.3.3] – 2026-08-13
 

--- a/src/cf_ips_to_hcloud_fw/models.py
+++ b/src/cf_ips_to_hcloud_fw/models.py
@@ -9,6 +9,61 @@ from pydantic import AfterValidator, BaseModel, ConfigDict, Field, SecretStr
 
 _Network = TypeVar("_Network", IPv4Network, IPv6Network)
 
+# Special-purpose blocks that must never reach a Cloudflare-only allow rule
+# (IANA IPv4/IPv6 Special-Purpose Address Registries, plus multicast).
+#
+# These are tested with `overlaps()`, NOT with the ipaddress `is_*` flags. On a
+# *network*, those flags are a conjunction over the two endpoints -
+# `network_address.is_private and broadcast_address.is_private` - so a range
+# that merely CONTAINS private space sets none of them: `128.0.0.0/1` spans
+# half of IPv4, subsumes 192.168.0.0/16, and reports is_private False. Overlap
+# is the containment-correct question to ask.
+_RESERVED_IPV4 = tuple(
+    IPv4Network(c)
+    for c in (
+        "0.0.0.0/8",  # "this network"
+        "10.0.0.0/8",  # private
+        "100.64.0.0/10",  # carrier-grade NAT
+        "127.0.0.0/8",  # loopback
+        "169.254.0.0/16",  # link-local
+        "172.16.0.0/12",  # private
+        "192.0.0.0/24",  # IETF protocol assignments
+        "192.0.2.0/24",  # TEST-NET-1
+        "192.168.0.0/16",  # private
+        "198.18.0.0/15",  # benchmarking
+        "198.51.100.0/24",  # TEST-NET-2
+        "203.0.113.0/24",  # TEST-NET-3
+        "224.0.0.0/4",  # multicast
+        "240.0.0.0/4",  # reserved, incl. 255.255.255.255 broadcast
+    )
+)
+_RESERVED_IPV6 = tuple(
+    IPv6Network(c)
+    for c in (
+        "::/128",  # unspecified
+        "::1/128",  # loopback
+        "::ffff:0:0/96",  # IPv4-mapped
+        "64:ff9b::/96",  # IPv4/IPv6 translation
+        "100::/64",  # discard-only
+        "2001::/32",  # Teredo
+        "2001:10::/28",  # ORCHID
+        "2001:db8::/32",  # documentation
+        "2002::/16",  # 6to4
+        "fc00::/7",  # unique local
+        "fe80::/10",  # link-local
+        "ff00::/8",  # multicast
+    )
+)
+
+# Floors on how broad a single published range may be. Cloudflare's live list
+# bottoms out at /13 (IPv4) and /29 (IPv6), so these sit 32x and 8192x broader
+# than anything actually published - wide enough that a legitimately broader
+# future range still passes, tight enough that a spanning aggregate cannot.
+# Defence in depth: `overlaps()` above already rejects every aggregate large
+# enough to swallow a reserved block.
+_MIN_PREFIXLEN_IPV4 = 8
+_MIN_PREFIXLEN_IPV6 = 16
+
 
 def _require_globally_routable(network: _Network) -> _Network:
     """Reject CIDRs that must never end up in a Cloudflare-only allow rule.
@@ -17,14 +72,10 @@ def _require_globally_routable(network: _Network) -> _Network:
     API response could hand us a range that is syntactically fine and
     semantically catastrophic: ``0.0.0.0/0`` passes every structural check and
     would open every marked firewall rule to the whole internet. Cloudflare
-    only ever publishes globally routable unicast space - the live list bottoms
-    out at /13 for IPv4 and /29 for IPv6 - so anything else is a broken payload
-    rather than a range worth syncing.
+    only ever publishes globally routable unicast space, so anything else is a
+    broken payload rather than a range worth syncing.
 
-    Deliberately no minimum prefix length: a floor tight enough to be useful
-    would hard-fail the run if Cloudflare ever published a broader aggregate,
-    turning a hypothetical tampering risk into a real outage with stale rules.
-    ``is_reserved`` is left out for the same reason - for IPv6 it means "outside
+    ``is_reserved`` is deliberately not consulted: for IPv6 it means "outside
     IANA-allocated space", so an allocation newer than the running Python's
     tables would be refused, and unallocated space is not routable to an
     attacker anyway.
@@ -36,27 +87,28 @@ def _require_globally_routable(network: _Network) -> _Network:
         The network unchanged, when it is globally routable.
 
     Raises:
-        ValueError: If the network is a default route or non-global space.
+        ValueError: If the network is over-broad or overlaps reserved space.
     """
-    # A default route needs its own test: `IPv4Network("0.0.0.0/0").is_private`
-    # is False, so the flag checks below do not catch it.
-    if network.prefixlen == 0:
-        msg = f"{network} is a default route"
+    if isinstance(network, IPv4Network):
+        reserved: tuple = _RESERVED_IPV4
+        floor = _MIN_PREFIXLEN_IPV4
+    else:
+        reserved = _RESERVED_IPV6
+        floor = _MIN_PREFIXLEN_IPV6
+
+    if network.prefixlen < floor:
+        msg = (
+            f"{network} is not globally routable: broader than /{floor}, and "
+            "Cloudflare does not publish ranges this large"
+        )
         raise ValueError(msg)
 
-    disallowed = [
-        name
-        for name, matches in (
-            ("unspecified", network.is_unspecified),
-            ("loopback", network.is_loopback),
-            ("link-local", network.is_link_local),
-            ("multicast", network.is_multicast),
-            ("private", network.is_private),
+    overlapping = [str(block) for block in reserved if network.overlaps(block)]
+    if overlapping:
+        msg = (
+            f"{network} is not globally routable: overlaps reserved space "
+            f"({', '.join(overlapping)})"
         )
-        if matches
-    ]
-    if disallowed:
-        msg = f"{network} is not globally routable ({', '.join(disallowed)})"
         raise ValueError(msg)
 
     return network

--- a/src/cf_ips_to_hcloud_fw/models.py
+++ b/src/cf_ips_to_hcloud_fw/models.py
@@ -9,8 +9,9 @@ from pydantic import AfterValidator, BaseModel, ConfigDict, Field, SecretStr
 
 _Network = TypeVar("_Network", IPv4Network, IPv6Network)
 
-# Special-purpose blocks that must never reach a Cloudflare-only allow rule
-# (IANA IPv4/IPv6 Special-Purpose Address Registries, plus multicast).
+# Special-purpose blocks that must never reach a Cloudflare-only allow rule:
+# the not-globally-reachable entries of the IANA IPv4 Special-Purpose Address
+# Registry, plus multicast and the reserved 240.0.0.0/4.
 #
 # These are tested with `overlaps()`, NOT with the ipaddress `is_*` flags. On a
 # *network*, those flags are a conjunction over the two endpoints -
@@ -29,7 +30,11 @@ _RESERVED_IPV4 = tuple(
         "172.16.0.0/12",  # private
         "192.0.0.0/24",  # IETF protocol assignments
         "192.0.2.0/24",  # TEST-NET-1
+        "192.31.196.0/24",  # AS112-v4
+        "192.52.193.0/24",  # AMT
+        "192.88.99.0/24",  # deprecated 6to4 relay anycast
         "192.168.0.0/16",  # private
+        "192.175.48.0/24",  # direct delegation AS112
         "198.18.0.0/15",  # benchmarking
         "198.51.100.0/24",  # TEST-NET-2
         "203.0.113.0/24",  # TEST-NET-3
@@ -79,6 +84,16 @@ def _require_globally_routable(network: _Network) -> _Network:
     tables would be refused, and unallocated space is not routable to an
     attacker anyway.
 
+    Note the blast radius of a false rejection. ``overlaps()`` is bidirectional,
+    so this refuses a range that merely *contains* a reserved block, and
+    ``get_cloudflare_cidrs`` turns any rejection into ``log_error_and_exit`` -
+    one bad CIDR aborts the whole sync and leaves every firewall on stale
+    rules. That is deliberate: dropping the offending range and syncing the
+    rest would quietly narrow the allow-list and break real traffic, which is
+    harder to notice than a loud non-zero exit the scheduler already alerts on.
+    It does mean the blocks listed above must stay conservative - each one is a
+    range Cloudflare can never legitimately publish.
+
     Args:
         network: A parsed CIDR from the Cloudflare response.
 
@@ -95,17 +110,21 @@ def _require_globally_routable(network: _Network) -> _Network:
         reserved = _RESERVED_IPV6
         floor = _MIN_PREFIXLEN_IPV6
 
-    if network.prefixlen < floor:
-        msg = (
-            f"{network} is not globally routable: broader than /{floor}, and "
-            "Cloudflare does not publish ranges this large"
-        )
-        raise ValueError(msg)
-
+    # Containment is checked before the floor so the message names the real
+    # reason: fc00::/7, fe80::/10 and ff00::/8 are all shorter than the /16
+    # floor, and reporting them as merely "too broad" would send an operator
+    # looking for a prefix problem when the range is not unicast at all.
     if isinstance(network, IPv6Network) and not network.subnet_of(_GLOBAL_UNICAST_IPV6):
         msg = (
             f"{network} is not globally routable: outside global unicast "
             f"{_GLOBAL_UNICAST_IPV6}"
+        )
+        raise ValueError(msg)
+
+    if network.prefixlen < floor:
+        msg = (
+            f"{network} is not globally routable: broader than /{floor}, and "
+            "Cloudflare does not publish ranges this large"
         )
         raise ValueError(msg)
 

--- a/src/cf_ips_to_hcloud_fw/models.py
+++ b/src/cf_ips_to_hcloud_fw/models.py
@@ -37,21 +37,20 @@ _RESERVED_IPV4 = tuple(
         "240.0.0.0/4",  # reserved, incl. 255.255.255.255 broadcast
     )
 )
+# IPv6 takes the inverse approach: rather than enumerate everything that is not
+# globally reachable, require membership of global unicast (RFC 4291) and list
+# only the special-purpose blocks that sit *inside* it. That closes the whole
+# outside-2000::/3 space in one rule - unique-local, link-local, multicast,
+# IPv4-mapped, NAT64, SRv6 SIDs (5f00::/16), IANA-reserved 400::/6 - without
+# needing an exhaustive registry copy that goes stale as IANA adds entries.
+_GLOBAL_UNICAST_IPV6 = IPv6Network("2000::/3")
 _RESERVED_IPV6 = tuple(
     IPv6Network(c)
     for c in (
-        "::/128",  # unspecified
-        "::1/128",  # loopback
-        "::ffff:0:0/96",  # IPv4-mapped
-        "64:ff9b::/96",  # IPv4/IPv6 translation
-        "100::/64",  # discard-only
-        "2001::/32",  # Teredo
-        "2001:10::/28",  # ORCHID
+        "2001::/23",  # IETF protocol assignments (Teredo, benchmarking, ORCHID)
         "2001:db8::/32",  # documentation
         "2002::/16",  # 6to4
-        "fc00::/7",  # unique local
-        "fe80::/10",  # link-local
-        "ff00::/8",  # multicast
+        "3fff::/20",  # documentation (RFC 9637)
     )
 )
 
@@ -100,6 +99,13 @@ def _require_globally_routable(network: _Network) -> _Network:
         msg = (
             f"{network} is not globally routable: broader than /{floor}, and "
             "Cloudflare does not publish ranges this large"
+        )
+        raise ValueError(msg)
+
+    if isinstance(network, IPv6Network) and not network.subnet_of(_GLOBAL_UNICAST_IPV6):
+        msg = (
+            f"{network} is not globally routable: outside global unicast "
+            f"{_GLOBAL_UNICAST_IPV6}"
         )
         raise ValueError(msg)
 

--- a/tests/test_cloudflare.py
+++ b/tests/test_cloudflare.py
@@ -153,7 +153,7 @@ def test_get_cloudflare_cidrs_empty_ipv6(mock_logging: MagicMock) -> None:
     MagicMock(
         return_value=cloudflare.types.ips.ip_list_response.PublicIPIPs(
             ipv4_cidrs=["399.27.128.0/21", "198.27.128.0/21"],
-            ipv6_cidrs=["2400:cb00::/32", "1400:cb00::/32"],
+            ipv6_cidrs=["2400:cb00::/32", "2606:4700::/32"],
         )
     ),
 )
@@ -208,7 +208,7 @@ def test_get_cloudflare_cidrs_rejects_unroutable(
     MagicMock(
         return_value=cloudflare.types.ips.ip_list_response.PublicIPIPs(
             ipv4_cidrs=["199.27.128.0/21", "198.27.128.0/21"],
-            ipv6_cidrs=["2400:cb00::/32", "1400:cb00::/32"],
+            ipv6_cidrs=["2606:4700::/32", "2400:cb00::/32"],
         )
     ),
 )
@@ -217,5 +217,5 @@ def test_get_cloudflare_cidrs() -> None:
     result = get_cloudflare_cidrs()
     assert result == CloudflareCIDRs(
         ipv4_cidrs=["198.27.128.0/21", "199.27.128.0/21"],
-        ipv6_cidrs=["1400:cb00::/32", "2400:cb00::/32"],
+        ipv6_cidrs=["2400:cb00::/32", "2606:4700::/32"],
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -67,6 +67,10 @@ def test_cloudflare_ip_networks_accepts_published_ranges() -> None:
         "224.0.0.0/4",
         "240.0.0.0/4",
         "198.51.100.0/24",
+        "192.31.196.0/24",  # AS112-v4
+        "192.52.193.0/24",  # AMT
+        "192.88.99.0/24",  # deprecated 6to4 relay anycast
+        "192.175.48.0/24",  # direct delegation AS112
     ],
 )
 def test_cloudflare_ip_networks_rejects_unroutable_ipv4(cidr: str) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -78,13 +78,48 @@ def test_cloudflare_ip_networks_rejects_unroutable_ipv4(cidr: str) -> None:
 
 @pytest.mark.parametrize(
     "cidr",
-    ["fc00::/7", "fe80::/10", "ff00::/8", "2001:db8::/32", "2002::/16", "::1/128"],
+    [
+        # Outside global unicast 2000::/3 — rejected by the containment rule.
+        "fc00::/7",  # unique local
+        "fe80::/10",  # link-local
+        "ff00::/8",  # multicast
+        "::1/128",  # loopback
+        "::ffff:0:0/96",  # IPv4-mapped
+        "64:ff9b::/96",  # NAT64
+        "64:ff9b:1::/48",  # NAT64 local-use
+        "100::/64",  # discard-only
+        "100:0:0:1::/64",  # dummy prefix (RFC 9780)
+        "5f00::/16",  # SRv6 SIDs (RFC 9602)
+        "4000::/16",  # IANA-reserved 400::/6
+        # Inside 2000::/3 — need an explicit block entry.
+        "2001::/32",  # Teredo
+        "2001:2::/48",  # benchmarking
+        "2001:10::/28",  # ORCHID
+        "2001:db8::/32",  # documentation
+        "2002::/16",  # 6to4
+        "3fff::/20",  # documentation (RFC 9637)
+    ],
 )
 def test_cloudflare_ip_networks_rejects_unroutable_ipv6(cidr: str) -> None:
     """Unroutable IPv6 ranges are rejected with an explanatory message."""
     with pytest.raises(ValidationError) as e:
         CloudflareIPNetworks(ipv4_cidrs=["198.27.128.0/21"], ipv6_cidrs=[cidr])
     assert _REJECTED in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "cidr",
+    ["2001:200::/32", "2400:cb00::/32", "2a06:98c0::/29", "3000::/16"],
+)
+def test_cloudflare_ip_networks_accepts_global_unicast_ipv6(cidr: str) -> None:
+    """Real global-unicast allocations must survive the containment rule.
+
+    ``2001:200::/32`` is the important one: it is a genuine APNIC allocation
+    that sits just past the ``2001::/23`` protocol-assignments block, so an
+    over-broad reserved entry would wrongly refuse it.
+    """
+    networks = CloudflareIPNetworks(ipv4_cidrs=["198.27.128.0/21"], ipv6_cidrs=[cidr])
+    assert len(networks.ipv6_cidrs) == 1
 
 
 # Aggregates whose two endpoints each look routable in isolation. The

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from ipaddress import IPv4Network, ip_network
+
 import pytest
 from pydantic import SecretStr, ValidationError
 
@@ -9,7 +11,7 @@ from cf_ips_to_hcloud_fw.models import CloudflareIPNetworks, Project
 
 # Every CIDR Cloudflare publishes today, as a guard against the routability
 # check rejecting a real response. The live list bottoms out at /13 for IPv4
-# and /29 for IPv6, which is why no minimum prefix length is enforced.
+# and /29 for IPv6, so the /8 and /16 floors leave a wide margin.
 PUBLISHED_IPV4_CIDRS = [
     "173.245.48.0/20",
     "103.21.244.0/22",
@@ -37,6 +39,11 @@ PUBLISHED_IPV6_CIDRS = [
     "2c0f:f248::/32",
 ]
 
+# A range can be refused either for being over-broad or for overlapping
+# reserved space; which guard fires first is an implementation detail, so the
+# tests assert only that the payload was refused as unroutable.
+_REJECTED = "not globally routable"
+
 
 def test_cloudflare_ip_networks_accepts_published_ranges() -> None:
     """The published Cloudflare ranges must all pass the routability check."""
@@ -49,37 +56,111 @@ def test_cloudflare_ip_networks_accepts_published_ranges() -> None:
 
 
 @pytest.mark.parametrize(
-    ("cidr", "reason"),
+    "cidr",
     [
-        ("0.0.0.0/0", "default route"),
-        ("10.0.0.0/8", "not globally routable (private)"),
-        ("127.0.0.0/8", "not globally routable"),
-        ("169.254.0.0/16", "not globally routable"),
-        ("224.0.0.0/4", "not globally routable (multicast)"),
-        ("240.0.0.0/4", "not globally routable"),
+        "10.0.0.0/8",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "100.64.0.0/10",
+        "224.0.0.0/4",
+        "240.0.0.0/4",
+        "198.51.100.0/24",
     ],
 )
-def test_cloudflare_ip_networks_rejects_unroutable_ipv4(cidr: str, reason: str) -> None:
+def test_cloudflare_ip_networks_rejects_unroutable_ipv4(cidr: str) -> None:
     """Unroutable IPv4 ranges are rejected with an explanatory message."""
     with pytest.raises(ValidationError) as e:
         CloudflareIPNetworks(ipv4_cidrs=[cidr], ipv6_cidrs=["2400:cb00::/32"])
-    assert reason in str(e.value)
+    assert _REJECTED in str(e.value)
 
 
 @pytest.mark.parametrize(
-    ("cidr", "reason"),
-    [
-        ("::/0", "default route"),
-        ("fc00::/7", "not globally routable (private)"),
-        ("fe80::/10", "not globally routable"),
-        ("ff00::/8", "not globally routable (multicast)"),
-    ],
+    "cidr",
+    ["fc00::/7", "fe80::/10", "ff00::/8", "2001:db8::/32", "2002::/16", "::1/128"],
 )
-def test_cloudflare_ip_networks_rejects_unroutable_ipv6(cidr: str, reason: str) -> None:
+def test_cloudflare_ip_networks_rejects_unroutable_ipv6(cidr: str) -> None:
     """Unroutable IPv6 ranges are rejected with an explanatory message."""
     with pytest.raises(ValidationError) as e:
         CloudflareIPNetworks(ipv4_cidrs=["198.27.128.0/21"], ipv6_cidrs=[cidr])
-    assert reason in str(e.value)
+    assert _REJECTED in str(e.value)
+
+
+# Aggregates whose two endpoints each look routable in isolation. The
+# ipaddress is_* flags are a conjunction over network_address and
+# broadcast_address, so every one of these reported is_private=False and
+# passed the earlier endpoint-based check while subsuming private space -
+# 128.0.0.0/1 contains 192.168.0.0/16, 0.0.0.0/1 contains 10.0.0.0/8.
+@pytest.mark.parametrize(
+    "cidr",
+    [
+        "0.0.0.0/0",
+        "0.0.0.0/1",
+        "128.0.0.0/1",
+        "0.0.0.0/2",
+        "64.0.0.0/2",
+        "128.0.0.0/2",
+        "192.0.0.0/2",
+        "0.0.0.0/4",
+        "128.0.0.0/7",
+    ],
+)
+def test_cloudflare_ip_networks_rejects_ipv4_aggregates(cidr: str) -> None:
+    """Spanning aggregates must not slip past on endpoint semantics alone."""
+    with pytest.raises(ValidationError) as e:
+        CloudflareIPNetworks(ipv4_cidrs=[cidr], ipv6_cidrs=["2400:cb00::/32"])
+    assert _REJECTED in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "cidr",
+    ["::/0", "::/1", "8000::/1", "4000::/2", "2000::/3", "::/15"],
+)
+def test_cloudflare_ip_networks_rejects_ipv6_aggregates(cidr: str) -> None:
+    """Same endpoint-semantics bypass on the IPv6 path."""
+    with pytest.raises(ValidationError) as e:
+        CloudflareIPNetworks(ipv4_cidrs=["198.27.128.0/21"], ipv6_cidrs=[cidr])
+    assert _REJECTED in str(e.value)
+
+
+def test_no_accepted_ipv4_range_can_contain_private_space() -> None:
+    """No accepted IPv4 range may overlap reserved space, swept exhaustively.
+
+    An oracle independent of the validator's own reasoning: every /8, /9, /10
+    and /12 is offered, and anything accepted must not overlap RFC 1918,
+    loopback, link-local, CGNAT, multicast or reserved space. The earlier
+    endpoint-based implementation failed this at /8 and above.
+    """
+    forbidden = [
+        ip_network(c)
+        for c in (
+            "10.0.0.0/8",
+            "172.16.0.0/12",
+            "192.168.0.0/16",
+            "127.0.0.0/8",
+            "169.254.0.0/16",
+            "100.64.0.0/10",
+            "224.0.0.0/4",
+            "240.0.0.0/4",
+        )
+    ]
+    checked = 0
+    for prefixlen in (8, 9, 10, 12):
+        step = 2 ** (32 - prefixlen)
+        for base in range(0, 2**32, step):
+            net = IPv4Network((base, prefixlen))
+            try:
+                CloudflareIPNetworks(
+                    ipv4_cidrs=[str(net)], ipv6_cidrs=["2400:cb00::/32"]
+                )
+            except ValidationError:
+                continue
+            checked += 1
+            assert not any(net.overlaps(f) for f in forbidden), (
+                f"{net} was accepted but overlaps reserved space"
+            )
+    assert checked > 0  # the sweep actually exercised accepted ranges
 
 
 def test_project_valid() -> None:


### PR DESCRIPTION
Fixes a hole in the routability check added earlier this cycle (#1439). Found by a
re-scan; I confirmed it before writing the fix.

## The bug

The check asked the wrong question. On a **network**, `ipaddress`'s `is_private`,
`is_loopback`, `is_link_local`, `is_multicast` and `is_unspecified` are a conjunction over
the two endpoints — `network_address.is_private and broadcast_address.is_private` — so a
range that merely *contains* private space sets none of them.

Every one of these was accepted before this change:

| CIDR | Subsumes | Old flags |
| --- | --- | --- |
| `128.0.0.0/1` | `192.168.0.0/16`, `224.0.0.0/4`, `240.0.0.0/4` | all False |
| `0.0.0.0/1` | `10.0.0.0/8`, `127.0.0.0/8` | all False |
| `0.0.0.0/2`, `64.0.0.0/2`, `192.0.0.0/2` | assorted reserved space | all False |
| `8000::/1`, `::/1` | `fc00::/7`, `fe80::/10`, `ff00::/8` | all False |

Only `prefixlen == 0` was caught, by its own special case.

The existing tests all used *exact* special-purpose ranges (`10.0.0.0/8`, `fc00::/7`),
where both endpoints do sit inside the block — so they passed and gave false confidence in
the endpoint semantics.

## The fix

`overlaps()` against the IANA special-purpose registries, which is the containment-correct
question, plus prefix floors of /8 (IPv4) and /16 (IPv6).

The floors are a **reversal of the reasoning in #1439**, which argued against any floor on
the grounds that it would hard-fail the run if Cloudflare published a broader aggregate.
That holds for a floor near the live minimum — but /8 and /16 sit 32× and 8192× broader
than the /13 and /29 the published list actually bottoms out at, so the false-rejection
risk is negligible while the bypass class it closes is not. They're defence in depth
anyway: `overlaps()` already rejects every aggregate broad enough to swallow a reserved
block.

## Verification

- **Live API response: all 22 published CIDRs still accepted.** This was the check that
  mattered most — a false rejection here means a hard exit and stale firewall rules.
- Every reported bypass now rejected, both families, including `/2` shapes the report
  didn't list.
- All previously-covered exact ranges stay rejected.
- New exhaustive sweep over the /8, /9, /10 and /12 space asserting nothing accepted
  overlaps reserved space — an oracle independent of the validator's own logic. The
  previous implementation fails it.

`make lint` and `make test` pass; coverage stays at 100%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of Cloudflare IP ranges against reserved and special-purpose address spaces.
  * Rejects IPv4 ranges broader than `/8` and IPv6 ranges broader than `/16`.
  * Provides clearer errors when ranges are too broad or overlap non-routable address blocks.

* **Documentation**
  * Updated the v1.3.4 changelog to document the enhanced IP range validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->