### PR TITLE
fix(config)!: exit non-zero when a config file has no projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ## [v1.3.4] – Unreleased
 
 - Start new development cycle
+- **Breaking:** A config file containing no projects now exits 1 instead of 0.
+  `[]` is a valid YAML document, so a truncated file or a mis-rendered template
+  validated cleanly and synced nothing — while the exit code told systemd, a
+  Kubernetes CronJob, or a cron wrapper the run was healthy and the firewall
+  rules quietly froze at their last-synced state. The environment-variable path
+  already failed loudly for the same condition; the two now agree
 - **Security:** Hetzner API tokens can no longer reach the log stream through
   third-party exception text. A token carrying a trailing newline — routine for
   a Kubernetes secret mounted as a file, or a YAML block scalar — made

--- a/src/cf_ips_to_hcloud_fw/config.py
+++ b/src/cf_ips_to_hcloud_fw/config.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 import stat
-import sys
 
 # coverage.py's sys.monitoring tracer (Python 3.14) calls os.stat while tracing;
 # binding stat under a private name lets tests patch config's own lookup without
@@ -125,8 +124,16 @@ def _read_config(config_file: str) -> list[Project]:
         log_error_and_exit(f"Config file {config_file!r} is broken: {sanitized_errors}")
 
     if not projects:
-        logging.warning(f"Config file {config_file!r} contains no projects - exiting")
-        sys.exit(0)
+        # Non-zero, not a clean exit. An empty list is a valid YAML document, so
+        # a truncated file or a mis-rendered template validates fine and syncs
+        # nothing; exiting 0 told every exit-code-keyed monitor - systemd,
+        # a Kubernetes CronJob, a cron wrapper - that the run was healthy while
+        # the firewall rules quietly froze at their last-synced state. The
+        # env-var path already fails loudly for the same condition.
+        log_error_and_exit(
+            f"Config file {config_file!r} contains no projects - no firewalls "
+            "would be synced. Add at least one project entry."
+        )
 
     return projects
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -195,14 +195,20 @@ def test_read_config_empty(mock_logging: MagicMock) -> None:
 
 
 @patch("builtins.open", mock_open(read_data="[]"))
-@patch("logging.warning")
+@patch("logging.error")
 def test_read_config_empty_list(mock_logging: MagicMock) -> None:
-    """Empty project lists exit with code 0 after warning the operator."""
+    """An empty project list fails the run rather than reporting success.
+
+    `[]` is a valid YAML document, so a truncated file or a mis-rendered
+    template validates cleanly and syncs nothing. Exiting 0 would tell an
+    exit-code-keyed monitor the run was healthy while the firewall rules froze.
+    """
     with pytest.raises(SystemExit) as e:
         _read_config("config.yaml")
-    assert e.value.code == 0
+    assert e.value.code == 1
     mock_logging.assert_called_once_with(
-        "Config file 'config.yaml' contains no projects - exiting",
+        "Config file 'config.yaml' contains no projects - no firewalls would "
+        "be synced. Add at least one project entry."
     )
 
 


### PR DESCRIPTION
Scan finding #4.

## The bug

`[]` is a valid YAML document. A truncated file or a mis-rendered template validates
cleanly, syncs nothing, and exits **0** — so systemd, a Kubernetes CronJob, or a cron
wrapper reads the run as healthy while the firewall rules freeze at their last-synced
state. Cloudflare ranges drift away unnoticed, and a prefix Cloudflare later releases keeps
reaching the origin unproxied.

The environment-variable path already used `log_error_and_exit` for the equivalent
condition (`HCLOUD_FIREWALLS` empty), so the two entry points disagreed on whether
"configured to do nothing" is a failure. They now agree that it is.

## Why this is the right direction, not just a fresh opinion

The exit-0 behaviour dates to the original module split (#64) with no stated rationale, and
the project has since moved the other way — **v1.2.0** made "firewalls not found" a
breaking exit-1 change for exactly this reason. Every other fatal config error (missing
file, broken YAML, bad permissions) already exits 1, so this isn't a new failure mode for
schedulers, just a consistent one.

Checked before changing it: no documentation states an exit code for this case, and a
single test pinned the old behaviour.

## Breaking

An empty config that previously exited 0 now exits 1. Marked `**Breaking:**` in the
CHANGELOG.

**Release note:** this project files breaking changes under *minor* releases (v1.3.0 for
the POSIX permission checks, v1.2.0 for the previous exit-behaviour change). The current
`1.3.4.dev1` is the expected intermediate state per the dev-cycle convention, but the
release should be cut as **1.4.0** rather than 1.3.4.

## Verification

`make lint` and `make test` pass — 150 tests, 100% coverage, with the new branch exercised
in both directions. Also dropped the now-unused `sys` import.
