### PR TITLE
fix(ci): stop a Dockerfile comment satisfying the provenance gate

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -138,27 +138,55 @@ jobs:
       # buildx setup to fail fast. Only the uv images are checkable here:
       # the python base is a Docker Official Image whose inline provenance is
       # unsigned (no verifiable signer). Refs are read from the Dockerfile so the
-      # pins stay single-sourced; the found guard trips if the pin format drifts
-      # and the grep silently matches nothing.
+      # pins stay single-sourced.
+      #
+      # Comments are stripped before matching and every uv reference must be
+      # digest-pinned. Scanning the raw file let a reference in a comment
+      # satisfy the guard while the real FROM pointed elsewhere, and counting
+      # any match let an unpinned `docker.io/astral/uv:latest` ride along
+      # unverified beside a pinned one — the first needs a deliberate edit, the
+      # second only a careless one. Both now fail the build.
       - name: Verify uv base image provenance
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
-          found=0
+          refs=""
+          count=0
+          while IFS= read -r line; do
+            # Drop comments before matching. A Dockerfile comment is a whole
+            # line, so this empties those outright; anything after a '#' on an
+            # instruction line is an argument Docker would reject, never a ref
+            # worth verifying. Everything else is still scanned, so a uv image
+            # pulled by COPY --from= or RUN --mount=,from= is covered too.
+            line="${line%%#*}"
+            case "$line" in
+              *docker.io/astral/uv[:@]*) ;;
+              *) continue ;;
+            esac
+            count=$((count + 1))
+            # The tag is optional: `uv@sha256:...` is the strongest pin form.
+            ref="$(printf '%s\n' "$line" |
+              grep -oE 'docker\.io/astral/uv(:[^ @]+)?@sha256:[0-9a-f]{64}' || true)"
+            if [ -z "$ref" ]; then
+              echo "::error::uv image is not digest-pinned:$line"
+              exit 1
+            fi
+            refs="$refs$ref"$'\n'
+          done < Dockerfile
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No uv image found in Dockerfile — verification would be a no-op"
+            exit 1
+          fi
           while IFS= read -r image; do
-            found=1
+            [ -n "$image" ] || continue
             echo "::group::verify $image"
             gh attestation verify "oci://$image" \
               --owner astral-sh \
               --predicate-type https://slsa.dev/provenance/v1
             echo "::endgroup::"
-          done < <(grep -oE 'docker\.io/astral/uv:[^ @]+@sha256:[0-9a-f]{64}' Dockerfile | sort -u)
-          if [ "$found" -eq 0 ]; then
-            echo "::error::No uv base images found in Dockerfile — verification would be a no-op"
-            exit 1
-          fi
+          done < <(printf '%s' "$refs" | sort -u)
 
       - name: Docker meta
         id: docker-meta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 ## [v1.3.4] – Unreleased
 
 - Start new development cycle
+- **Security:** The uv base-image provenance gate can no longer be satisfied by
+  a Dockerfile comment. It grepped the whole file, so a well-formed
+  `docker.io/astral/uv:…@sha256:…` reference on a comment line passed
+  verification while the real `FROM` pointed anywhere — publishing an image
+  built on an unattested base with the provenance check reported green.
+  Comments are now stripped before matching, and every uv reference the file
+  pulls must be digest-pinned, which also closes an unpinned
+  `docker.io/astral/uv:latest` riding along unverified beside a pinned one.
+  Tagless digest pins (`uv@sha256:…`) and images pulled by `COPY --from=` are
+  covered too
 - **Breaking:** A config file containing no projects now exits 1 instead of 0.
   `[]` is a valid YAML document, so a truncated file or a mis-rendered template
   validated cleanly and synced nothing — while the exit code told systemd, a


### PR DESCRIPTION
Scan finding #1, the highest-severity of the set. Reproduced before fixing.

## The bug

The step grepped the whole Dockerfile for a pinned uv reference. grep has no notion of
Dockerfile syntax, so a comment line is indistinguishable from a `FROM`:

```dockerfile
# docker.io/astral/uv:0.12.4-python3.14-trixie@sha256:2aae02…
FROM debian:bookworm-slim AS uv-tools-trixie
```

`found=1`, `gh attestation verify` succeeds against that genuine attested image, step exits
0 — while the build runs on `debian:bookworm-slim`. On a tag build that publishes to Docker
Hub, Quay and GHCR with the provenance check reported green.

## A second hole, not in the report

Found while reproducing the first:

```dockerfile
FROM docker.io/astral/uv:0.12.4@sha256:2aae02… AS a
FROM docker.io/astral/uv:latest AS b          # never verified
```

The unpinned ref matches nothing, so it's never verified — and `found=1` from the pinned
one carries the step to success. This needs no deception at all, just a careless edit, and
an unpinned base is precisely what the pinning policy exists to prevent.

## The fix

Comments are stripped before matching, and every uv reference must be digest-pinned or the
build fails.

Stripping is what makes a `FROM`-only filter unnecessary — a whole-line comment empties
out, so scanning every remaining line closes the bypass *and* keeps the breadth the old
grep had. A uv image pulled by `COPY --from=` or `RUN --mount=,from=` is still covered,
where a `FROM`-only guard would have quietly dropped it.

Tagless digest pins (`uv@sha256:…`) now match too. That's the strongest pin form, and the
old regex required a tag — so it would have been skipped silently next to a tagged pin.

## Verification

I extracted the step from the workflow YAML and ran *that* against eleven Dockerfile
variants, rather than testing a copy of the logic:

| Variant | Result |
| --- | --- |
| ref in a `#` comment | fails — no uv image found |
| `#FROM …` (no space) | fails |
| trailing `# …` after an unpinned FROM | fails — not digest-pinned |
| unpinned `:latest`, alone and beside a pinned one | fails, naming the line |
| no uv reference at all | fails |
| tagless `uv@sha256:…`, alone and beside a tagged pin | both verified |
| `COPY --from=` pinned / unpinned | verified / fails |
| lowercase `from`, indented `FROM` | verified |
| **real Dockerfile** | **both images verified** |

Worth noting on the trailing-comment case: Docker rejects it anyway (`FROM requires either
one or three arguments` — confirmed against Docker 29.7.2), so it was fail-closed already.
Stripping just moves the failure earlier and makes the extraction structurally correct.

`actionlint` and `zizmor` pass. No `${{ }}` interpolation added — the only input is the
repo's own Dockerfile.
