### PR TITLE
chore: ignore security-scan output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ coverage.xml
 htmlcov
 test-results.xml
 
+# Security scan output (vvaharness): reports plus an error log that can quote
+# scanned source. Regenerated per run and never committed.
+security-scan
+
 # OS artifacts
 .DS_Store
 


### PR DESCRIPTION
vvaharness writes its report, SARIF, raw stage output and error log to `security-scan/` in
the target repo. The directory was untracked and unignored, so a `git add -A` would have
swept the whole set into a commit — including an errors `.jsonl` that can quote scanned
source, and a `.claude/` directory the run drops alongside it.

Verified by recreating the artifact set from the last run, including the nested `.claude/`
dir, and confirming `git add -A` stages nothing from it:

```
$ git check-ignore -v security-scan/..._errors.jsonl security-scan/.claude/x/settings.json
.gitignore:33:security-scan	security-scan/..._errors.jsonl
.gitignore:33:security-scan	security-scan/.claude/x/settings.json
```

No trailing slash, matching the existing entries (`build`, `dist`, `htmlcov`).
