### PR TITLE
fix(ci): stop a fork PR steering the test-result publisher

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -27,9 +27,11 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     # Skip cancelled runs too: a run cancelled by concurrency (superseded
-    # push) or deleted afterwards has no test artifacts, so the download step
-    # would fail on nothing to publish. Failed runs still publish — a red test
-    # run must report its results.
+    # push) or deleted afterwards has no results worth publishing, and an empty
+    # check run would only bury the real one. Not a hard requirement any more —
+    # the download step warns rather than fails when nothing matches — so this
+    # is about signal, not about avoiding an error. Failed runs still publish:
+    # a red test run must report its results.
     if: ${{ github.event.workflow_run.conclusion != 'skipped' && github.event.workflow_run.conclusion != 'cancelled' }}
 
     permissions:
@@ -72,14 +74,25 @@ jobs:
       #
       # An empty object removes that: with no pull_request.number the action
       # falls back to resolving the PR from `commit` below, which comes from the
-      # workflow_run payload and is filtered against the PR's own head SHA. The
-      # file must still exist — the action treats a missing event_file as an
-      # unprivileged fork run (is_fork) and would skip publishing altogether.
+      # workflow_run payload and is filtered against the PR's own head SHA.
+      #
+      # The input must still be passed, and the file must exist. Omitting the
+      # input lets `event` fall back to GITHUB_EVENT_PATH — the workflow_run
+      # payload, which has no pull_request key — so is_fork becomes true for PR
+      # runs and both the check run and the comment are suppressed. Naming a
+      # file that is not there fails the step outright.
       #
       # The base-commit comparison survives: with a falsy event, the action's
       # get_base_commit_sha skips the event lookup and derives the merge base
       # from the API instead, so that figure now comes from GitHub rather than
       # from the same file an attacker controlled.
+      #
+      # One deliberate loss: pushes to the default branch no longer show the
+      # "compared against earlier commit" delta, which came from the push
+      # event's `before` field in the downloaded file. The workflow_run payload
+      # does not carry it, and reinstating it would mean another API lookup for
+      # a line nobody reads on a green build. PR runs are unaffected — a
+      # pull_request event has no `before` either way.
       - name: Write trusted event file
         shell: bash
         run: |

--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -50,17 +50,59 @@ jobs:
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
-          name: test-results-.*|event-file
+          name: test-results-.*
           name_is_regexp: true
           path: artifacts
+          # The action defaults to failing when nothing matches, and the
+          # event-file artifact used to guarantee a match. Now that only test
+          # results are downloaded, a run that failed before pytest produced any
+          # XML — a ruff or ty failure across the whole matrix — legitimately has
+          # nothing to fetch. Warn instead, and let the publish step report the
+          # empty result set.
+          if_no_artifact_found: warn
+
+      # The event file is written here rather than downloaded. GitHub runs the
+      # *fork's* copy of python-package.yaml for a fork PR, so anything that run
+      # uploads is attacker-controlled. The action reads pull_request.number
+      # straight out of the event file (publisher.py get_pull_from_event) and
+      # that lookup wins over the commit-based one, with only a
+      # base.repo.full_name check the same attacker also supplies — so a crafted
+      # file redirected this job's comment onto any PR in the repository, posted
+      # by the bot with pull-requests:write.
+      #
+      # An empty object removes that: with no pull_request.number the action
+      # falls back to resolving the PR from `commit` below, which comes from the
+      # workflow_run payload and is filtered against the PR's own head SHA. The
+      # file must still exist — the action treats a missing event_file as an
+      # unprivileged fork run (is_fork) and would skip publishing altogether.
+      #
+      # The base-commit comparison survives: with a falsy event, the action's
+      # get_base_commit_sha skips the event lookup and derives the merge base
+      # from the API instead, so that figure now comes from GitHub rather than
+      # from the same file an attacker controlled.
+      - name: Write trusted event file
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p trusted
+          echo '{}' > trusted/event.json
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/event-file/event.json
+          event_file: trusted/event.json
           event_name: ${{ github.event.workflow_run.event }}
           files: artifacts/test-results-*/*.xml
           comment_mode: ${{ github.event.workflow_run.event == 'pull_request' && 'always' || 'off' }}
           report_individual_runs: true
+          # Test names and failure messages come from the fork's own pytest run
+          # and render as markdown here. That is accepted rather than blocked:
+          # with the event file no longer steerable, the output lands on the
+          # contributor's own pull request, where they already control the
+          # title, body and diff. check_run_annotations_branch cannot narrow it
+          # — the action matches that list against GITHUB_REF, which a
+          # workflow_run job always reports as the default branch, so any value
+          # matches. The lever that would work is `check_run_annotations: none`,
+          # at the cost of inline annotations for every pull request.
           check_run_annotations_branch: "*"

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -17,24 +17,6 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
-  upload-event-file:
-    name: Upload event file
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          disable-sudo: true
-          egress-policy: block
-
-      - name: Upload
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: event-file
-          path: ${{ github.event_path }}
-          retention-days: 5
-
   test:
     name: Test
     runs-on: ubuntu-24.04
@@ -338,7 +320,6 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
     needs:
       - build-and-attest-dist
-      - upload-event-file
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 ## [v1.3.4] – Unreleased
 
 - Start new development cycle
+- **Security:** A fork pull request can no longer steer the test-result
+  publisher. GitHub runs the fork's copy of `python-package.yaml` for a fork PR,
+  so the `event-file` artifact it uploaded was attacker-controlled — and the
+  publishing action reads the target PR number straight out of that file, in
+  preference to resolving it from the commit. A crafted event file therefore
+  redirected the bot's comment onto any pull request in the repository. The
+  event file is now written in the trusted job instead of downloaded, so the PR
+  is resolved from the triggering run's own commit, and the artifact that made
+  this possible is no longer produced. The report's base-commit comparison now
+  comes from the GitHub API rather than that file
 - **Security:** The uv base-image provenance gate can no longer be satisfied by
   a Dockerfile comment. It grepped the whole file, so a well-formed
   `docker.io/astral/uv:…@sha256:…` reference on a comment line passed


### PR DESCRIPTION
Scan findings #2 and #3. #3 is the substantive one, and it **overturns advice I gave on the
previous scan** — I recommended accepting this as low-risk on the grounds that a fork author
"already controls their own PR." That premise is wrong.

## The bug

GitHub runs the **fork's copy** of `python-package.yaml` for a fork PR, so the `event-file`
artifact it uploaded was attacker-controlled. The publishing action reads the target PR
straight out of that file:

```python
# publisher.py:256
def get_pull_from_event(self):
    number = get_json_path(self._settings.event, 'pull_request.number')
    repo   = get_json_path(self._settings.event, 'pull_request.base.repo.full_name')
    if number is None or repo is None or repo != self._settings.repo: return None
    return self._repo.get_pull(number)
```

The only guard is `base.repo.full_name`, which the same attacker supplies. And this lookup
**wins** over the commit-based one, which is the safe path (it filters `commit in
[pull.head.sha, pull.merge_commit_sha]`).

So a crafted event file redirected the bot's comment onto **any open PR in the repository**,
posted with `pull-requests:write`, with the body derived from a paired JUnit XML the fork
also controls. That's the escalation my earlier "it's their own PR" reasoning missed.

## The fix

The event file is written in the trusted job as `{}`. With no `pull_request.number` the
action falls back to resolving the PR from `commit` — `workflow_run.head_sha`, which a fork
cannot forge.

The file has to exist and the input has to be passed: `is_fork = event_file is None and …`,
so dropping the input would make the action treat this as an unprivileged fork run and
suppress the check run and comment. My first instinct was to just remove it; reading the
source is what caught that.

`python-package.yaml` no longer uploads the artifact — nothing consumes it now, and its
only other reference was a `needs:` entry.

## Also fixed, from review

- **`if_no_artifact_found: warn`.** The default is `fail`, and `event-file` used to
  guarantee a match. Without it, a run that failed before pytest wrote any XML — ruff or ty
  failing across the matrix — would have turned this workflow red. That was a regression in
  my first draft.
- **Base-commit comparison survives.** I'd claimed it was lost; with a falsy event the
  action derives the merge base from the API instead, so it now comes from GitHub rather
  than the attacker-supplied file.
- **Default-branch pushes lose the "earlier commit" delta**, which came from the push
  event's `before` field. Documented rather than reinstated.

## What is *not* fixed: #2

Markdown injection into the comment body is **accepted, not blocked**. With the target no
longer steerable it lands on the contributor's own PR, where they already control the title,
body and diff.

`check_run_annotations_branch` cannot narrow it — the action matches that list against
`GITHUB_REF`, which a `workflow_run` job always reports as the default branch, so any value
matches and the input is inert here. My first draft set it to the default branch and claimed
containment; that was a no-op, now reverted to `"*"` with the reasoning recorded. The lever
that would work is `check_run_annotations: none`, at the cost of inline annotations on every
PR — say the word if that trade is worth it.

## Verification

Traced against both actions' source at their pinned SHAs. `actionlint` and `zizmor` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection for test-result publishing by using trusted workflow data.
  * Added stricter validation for container image provenance and network ranges.
  * Redacted credentials and sensitive details from error messages.
* **Bug Fixes**
  * Configurations with no entries now fail clearly instead of proceeding unexpectedly.
  * Improved handling of missing test-result artifacts without failing publication.
* **Maintenance**
  * Disabled automatic dependency digest updates for GitHub Actions.
  * Pinned Cloudflare API routing for more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->