### PR TITLE
docs(cloudflare): state what pinning the base URL actually closes

### DIFF
--- a/src/cf_ips_to_hcloud_fw/cloudflare.py
+++ b/src/cf_ips_to_hcloud_fw/cloudflare.py
@@ -27,7 +27,7 @@ _NO_AUTH_HEADERS = {
 # where the firewall's entire allow list comes from. Pinning it here makes that
 # one variable inert; the value is the SDK's own default.
 #
-# This is tidiness, not a security boundary, and the scope is worth being exact
+# That is a real boundary but a partial one, and the scope is worth being exact
 # about. The transport is deliberately left alone: httpx keeps trust_env=True,
 # so HTTPS_PROXY and SSL_CERT_FILE still apply and a principal who can set them
 # can still intercept the fetch. That is on purpose - operators behind a

--- a/src/cf_ips_to_hcloud_fw/cloudflare.py
+++ b/src/cf_ips_to_hcloud_fw/cloudflare.py
@@ -23,11 +23,22 @@ _NO_AUTH_HEADERS = {
 }
 
 # Passed explicitly because the SDK otherwise falls back to the
-# CLOUDFLARE_BASE_URL environment variable. The tool never advertised that knob,
-# and it decides where the firewall's entire allow list comes from, so anything
-# able to set an env var on the job - a CronJob spec, a compose file, a workflow
-# env block - could redirect the fetch to its own server. Pinning it here makes
-# the variable inert; the value is the SDK's own default.
+# CLOUDFLARE_BASE_URL environment variable, an undocumented knob that decides
+# where the firewall's entire allow list comes from. Pinning it here makes that
+# one variable inert; the value is the SDK's own default.
+#
+# This is tidiness, not a security boundary, and the scope is worth being exact
+# about. The transport is deliberately left alone: httpx keeps trust_env=True,
+# so HTTPS_PROXY and SSL_CERT_FILE still apply and a principal who can set them
+# can still intercept the fetch. That is on purpose - operators behind a
+# corporate egress proxy need it, and turning it off would break them with no
+# way to opt back in. The trade is easy because anyone able to set environment
+# variables on this job can already set HCLOUD_TOKEN, replace the config file,
+# or point PYTHONPATH at their own code; TLS interception is a longer road to
+# capabilities they already have. What actually guards a tampered response is
+# the routability check in models.py, and that is bounded too - it rejects
+# reserved and over-broad ranges, not a globally routable prefix an attacker
+# happens to control.
 CLOUDFLARE_API_BASE_URL = "https://api.cloudflare.com/client/v4"
 
 


### PR DESCRIPTION
Scan finding #1. Comment only — no behaviour change.

## The problem

The comment named "anything able to set an env var on the job" as the adversary, then closed
a single variable. That reads as though the env-var threat were handled. It isn't: httpx
keeps `trust_env=True`, so `HTTPS_PROXY` and `SSL_CERT_FILE` still apply and the same
principal can intercept the fetch.

Confirmed against the real code path:

```
$ HTTPS_PROXY=http://127.0.0.1:9 python -c "...cf_ips_list()"
exited via log_error_and_exit (connection failed)

$ python -c "...cf_ips_list()"          # control
fetched 15 v4 + 7 v6 CIDRs
```

## Why the transport is left alone

Deliberate, not an oversight. Operators behind a corporate egress proxy depend on
`trust_env`, and disabling it would break them with no way to opt back in — a concrete
regression traded against an attacker who can already set `HCLOUD_TOKEN`, replace the config
file, or point `PYTHONPATH` at their own code. TLS interception is a longer road to
capabilities they already have.

So the honest fix is to scope the claim, not to harden further. The comment now says the
pin closes one undocumented knob, that it's tidiness rather than a security boundary, and
that the actual guard against a tampered response is the routability check in `models.py` —
which is bounded too: it rejects reserved and over-broad ranges, not a globally routable
prefix an attacker happens to control.

If you'd rather pin the transport anyway, `http_client=httpx.Client(trust_env=False)` is the
one-liner — but it should come with a documented way to re-enable proxy support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how configuring the Cloudflare API base URL affects environment-variable overrides.
  * Documented that proxy and certificate settings remain available.
  * Added details about the resulting trust model and routability validation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->