### PR TITLE
fix(ci): key publisher concurrency on the fork, not just the branch

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -17,8 +17,18 @@ permissions:
 # workflow_run runs on the default-branch ref, so group by the *triggering*
 # run's branch — otherwise unrelated builds finishing together would cancel
 # each other's result publish.
+#
+# Keyed on the head repository as well, because a branch name is not unique
+# across forks: a fork PR from a branch called `main` produced the same group
+# as the base repo's own main-branch run, and cancel-in-progress then let the
+# fork's run cancel it — dropping test results for a push to main. Branch names
+# are unique within a repository, so the pair separates every fork from the base
+# repo; it does not separate two runs from the same branch of the same repo, but
+# those are the ones cancel-in-progress is meant to collapse anyway.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{
+    github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [v1.3.4] – Unreleased
 
 - Start new development cycle
+- Test-result publishing is no longer cancellable from a fork. The concurrency
+  group was keyed on the triggering run's branch name alone, so a fork pull
+  request from a branch called `main` shared a group with the base repository's
+  own main-branch run — and `cancel-in-progress` let the fork's run cancel it,
+  dropping the results for that push. The key now includes the head repository
 - **Security:** A fork pull request can no longer steer the test-result
   publisher. GitHub runs the fork's copy of `python-package.yaml` for a fork PR,
   so the `event-file` artifact it uploaded was attacker-controlled — and the


### PR DESCRIPTION
Scan finding #4, the last one from this run.

## The bug

The concurrency group was keyed on the triggering run's branch name alone:

```yaml
group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
```

Branch names are only unique *within* a repository. A fork PR from a branch called `main`
therefore produced the same group as the base repo's own main-branch run — and with
`cancel-in-progress: true`, the fork's run cancelled it, dropping the test results for that
push to main.

## The fix

Add `head_repository.full_name` to the key:

```
jkreileder/cf-ips-to-hcloud-fw  ->  'Publish test results-jkreileder/cf-ips-to-hcloud-fw-main'
attacker/cf-ips-to-hcloud-fw    ->  'Publish test results-attacker/cf-ips-to-hcloud-fw-main'
```

Base-repo runs all gain the same constant prefix, so their grouping is unchanged — the
change is strictly additive, only forks get a separate lane. The `owner/repo` prefix also
anchors it against a forged collision: `full_name` is delimited by the first `/`, so a fork
would need the base owner's name to reproduce the key.

## Verification

Two things that could have made this silently useless, both checked rather than assumed:

- **`head_repository.full_name` is populated** — confirmed against a real `workflow_run`
  object, not just the schema. A typo'd path would expand to empty and quietly restore the
  old behaviour.
- **The folded scalar folds correctly.** It splits mid-expression (`…-${{` / newline /
  `github.event.workflow_run.head_branch }}`); parsing the file confirms it collapses to the
  intended single line.

`actionlint`, `zizmor` and `markdownlint-cli2` pass.
