### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ debug logs).
 
 **Environment**<!-- markdownlint-disable-line MD036 -->
 
-- cf-ips-to-hcloud-fw version: [e.g. 1.3.3]
+- cf-ips-to-hcloud-fw version: [e.g. 1.4.0]
 - Deployment method: [e.g. Docker, Python module]
 - If Python module, Python version: [e.g. 3.14]
 - If Python module, OS: [e.g. macOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,34 +2,13 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.3.4] – Unreleased
+## [v1.4.0] – 2026-08-16
 
-- Start new development cycle
-- Test-result publishing is no longer cancellable from a fork. The concurrency
-  group was keyed on the triggering run's branch name alone, so a fork pull
-  request from a branch called `main` shared a group with the base repository's
-  own main-branch run — and `cancel-in-progress` let the fork's run cancel it,
-  dropping the results for that push. The key now includes the head repository
-- **Security:** A fork pull request can no longer steer the test-result
-  publisher. GitHub runs the fork's copy of `python-package.yaml` for a fork PR,
-  so the `event-file` artifact it uploaded was attacker-controlled — and the
-  publishing action reads the target PR number straight out of that file, in
-  preference to resolving it from the commit. A crafted event file therefore
-  redirected the bot's comment onto any pull request in the repository. The
-  event file is now written in the trusted job instead of downloaded, so the PR
-  is resolved from the triggering run's own commit, and the artifact that made
-  this possible is no longer produced. The report's base-commit comparison now
-  comes from the GitHub API rather than that file
-- **Security:** The uv base-image provenance gate can no longer be satisfied by
-  a Dockerfile comment. It grepped the whole file, so a well-formed
-  `docker.io/astral/uv:…@sha256:…` reference on a comment line passed
-  verification while the real `FROM` pointed anywhere — publishing an image
-  built on an unattested base with the provenance check reported green.
-  Comments are now stripped before matching, and every uv reference the file
-  pulls must be digest-pinned, which also closes an unpinned
-  `docker.io/astral/uv:latest` riding along unverified beside a pinned one.
-  Tagless digest pins (`uv@sha256:…`) and images pulled by `COPY --from=` are
-  covered too
+Security-hardening release. An agentic SAST sweep of the repository turned up a set of
+issues across the CLI and the release pipeline; every finding is either fixed here or
+recorded as accepted. The only behaviour change an existing deployment can notice is the
+exit code for an empty config, called out first below.
+
 - **Breaking:** A config file containing no projects now exits 1 instead of 0.
   `[]` is a valid YAML document, so a truncated file or a mis-rendered template
   validated cleanly and synced nothing — while the exit code told systemd, a
@@ -46,15 +25,7 @@
   hcloud's own `APIException`/`ActionException`, and `requests`' connection,
   TLS, proxy and timeout errors — keeps its full message, which is where the
   detail that makes a failed sync diagnosable lives
-- Config tokens are stripped of surrounding whitespace. A trailing newline is
-  not part of the credential, and carrying it previously made *every* API
-  request fail, since `requests` rejects a header value containing one
-- GitHub Actions digest refreshes are no longer automerged. The 3-day
-  `minimumReleaseAge` hold cannot gate them — the `github-tags` datasource ages
-  a digest against the matched version's original release date, so an action tag
-  force-pushed to new commits clears the check immediately. Image digests still
-  automerge, since Docker Hub's `tag_last_pushed` restarts the hold
-- Config file YAML parse errors no longer echo any part of the file into the
+- **Security:** Config file YAML parse errors no longer echo any part of the file into the
   log. PyYAML's error formatting embeds a snippet of the offending source line,
   which put the raw Hetzner API token into the log stream whenever the syntax
   error sat on or next to the `token:` line (an unterminated quote, a stray tab,
@@ -62,12 +33,7 @@
   names into its own error text, so a stray `*` or `&` before the value leaked
   it too. Errors now report only the error type plus the line and column,
   matching the redaction already applied to config validation errors
-- Pinned the Cloudflare API base URL in code. The SDK falls back to the
-  `CLOUDFLARE_BASE_URL` environment variable when no base URL is passed, so
-  anything able to set an env var on the job — a CronJob spec, a compose file, a
-  workflow env block — could point the IP fetch at its own server and dictate
-  what the firewall rules end up allowing. That variable is now inert
-- Cloudflare CIDR responses are checked for routability, not just syntax. A
+- **Security:** Cloudflare CIDR responses are checked for routability, not just syntax. A
   range is rejected if it overlaps IANA special-purpose space (RFC 1918,
   loopback, link-local, CGNAT, multicast, reserved, documentation) or is
   broader than /8 for IPv4 or /16 for IPv6, instead of being written verbatim
@@ -76,6 +42,44 @@
   hiding it inside an aggregate (`0.0.0.0/0`, `128.0.0.0/1`, `8000::/1`). The
   prefix floors sit far below the /13 and /29 the published list bottoms out
   at, so a legitimately broader range from Cloudflare will not fail the run
+- **Security:** The uv base-image provenance gate can no longer be satisfied by
+  a Dockerfile comment. It grepped the whole file, so a well-formed
+  `docker.io/astral/uv:…@sha256:…` reference on a comment line passed
+  verification while the real `FROM` pointed anywhere — publishing an image
+  built on an unattested base with the provenance check reported green.
+  Comments are now stripped before matching, and every uv reference the file
+  pulls must be digest-pinned, which also closes an unpinned
+  `docker.io/astral/uv:latest` riding along unverified beside a pinned one.
+  Tagless digest pins (`uv@sha256:…`) and images pulled by `COPY --from=` are
+  covered too
+- **Security:** A fork pull request can no longer steer the test-result
+  publisher. GitHub runs the fork's copy of `python-package.yaml` for a fork PR,
+  so the `event-file` artifact it uploaded was attacker-controlled — and the
+  publishing action reads the target PR number straight out of that file, in
+  preference to resolving it from the commit. A crafted event file therefore
+  redirected the bot's comment onto any pull request in the repository. The
+  event file is now written in the trusted job instead of downloaded, so the PR
+  is resolved from the triggering run's own commit, and the artifact that made
+  this possible is no longer produced. The report's base-commit comparison now
+  comes from the GitHub API rather than that file
+- Pinned the Cloudflare API base URL in code. The SDK falls back to the
+  `CLOUDFLARE_BASE_URL` environment variable when no base URL is passed, so
+  anything able to set an env var on the job — a CronJob spec, a compose file, a
+  workflow env block — could point the IP fetch at its own server and dictate
+  what the firewall rules end up allowing. That variable is now inert
+- Config tokens are stripped of surrounding whitespace. A trailing newline is
+  not part of the credential, and carrying it previously made *every* API
+  request fail, since `requests` rejects a header value containing one
+- GitHub Actions digest refreshes are no longer automerged. The 3-day
+  `minimumReleaseAge` hold cannot gate them — the `github-tags` datasource ages
+  a digest against the matched version's original release date, so an action tag
+  force-pushed to new commits clears the check immediately. Image digests still
+  automerge, since Docker Hub's `tag_last_pushed` restarts the hold
+- Test-result publishing is no longer cancellable from a fork. The concurrency
+  group was keyed on the triggering run's branch name alone, so a fork pull
+  request from a branch called `main` shared a group with the base repository's
+  own main-branch run — and `cancel-in-progress` let the fork's run cancel it,
+  dropping the results for that push. The key now includes the head repository
 
 ## [v1.3.3] – 2026-08-13
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.3.3
+  jkreileder/cf-ips-to-hcloud-fw:1.4.0
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -161,15 +161,15 @@ command override is needed:
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
   -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
-  jkreileder/cf-ips-to-hcloud-fw:1.3.3
+  jkreileder/cf-ips-to-hcloud-fw:1.4.0
 ```
 
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 `linux/arm64` architectures.  The Docker images support the following tags:
 
 - `1`: This tag always points to the latest `1.x.x` release.
-- `1.3`: This tag always points to the latest `1.3.x` release.
-- `1.3.3`: This tag points to the specific `1.3.3` release.
+- `1.4`: This tag always points to the latest `1.4.x` release.
+- `1.4.0`: This tag points to the specific `1.4.0` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -221,7 +221,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.3.3
+              image: jkreileder/cf-ips-to-hcloud-fw:1.4.0
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false
@@ -248,7 +248,7 @@ falls back to these variables:
 ```yaml
 containers:
   - name: cf-ips-to-hcloud-fw
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.3
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.0
     env:
       - name: HCLOUD_TOKEN
         valueFrom:
@@ -451,7 +451,7 @@ service that uses the image's default one-shot entrypoint:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.3
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.0
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
 ```
@@ -471,7 +471,7 @@ the `docker compose run` line above, or the override makes the run never exit:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.3.3
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.0
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
     # Re-run every 24h (86400s) inside one container instead of a scheduler.
@@ -518,7 +518,7 @@ with the `gh attestation verify --bundle` command shown below.
 
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.3.3
+VERSION=1.4.0
 
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
@@ -570,7 +570,7 @@ Build provenance:
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
 IMAGE_REPO=docker.io/jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.3.3
+VERSION=1.4.0
 IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 
 # Verifying build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.3.4.dev1"
+version = "1.4.0"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.3.4.dev1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Release v1.4.0. Bumps the version, finalizes the changelog, and updates the pinned version in the docs.

**Minor, not patch** — the empty-config exit code changed from 0 to 1 (#1447), and this project files breaking changes under minor releases (v1.3.0, v1.2.0).

Changelog housekeeping: dropped the placeholder bullet, dated the heading, ordered entries breaking-first then security, and marked the two runtime leaks (YAML parse errors, CIDR routability) `**Security:**` alongside the others — they were not when first written.

Doc bumps: the pinned image tag and attestation `VERSION=`, plus the minor tag bullet `1.3` → `1.4` to match what `docker-meta` publishes. The "Releases from v1.3.3 on" line is deliberately left alone — historical, not a pin.

`make lint`, `make test` (150 passed, 100%) and `make build` all pass; the local build produced the 1.4.0 wheel and sdist.