### PR TITLE
chore: start new development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- markdownlint-disable MD024 -->
 
+## [v1.4.1] – Unreleased
+
+- Start new development cycle
+
 ## [v1.4.0] – 2026-08-16
 
 Security-hardening release. An agentic SAST sweep of the repository turned up a set of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.4.0"
+version = "1.4.1.dev1"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.4.0"
+version = "1.4.1.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Begin v1.4.1 development. Bumps `pyproject.toml` to `1.4.1.dev1` (plus `uv.lock`, which records the project version) and opens a fresh `## [v1.4.1] – Unreleased` section.

Next patch by default per the dev-cycle convention; escalate to a minor later if the work warrants it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an unreleased changelog section for version 1.4.1.

* **Chores**
  * Updated the project version to indicate the start of the 1.4.1 development cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->