### PR TITLE
ci(docker): split attestation into its own job

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -339,9 +339,18 @@ jobs:
   # matters because a rebuild can never reproduce the pushed digest: buildx
   # provenance (mode=max) carries a fresh `invocationId` and startedOn/
   # finishedOn per build, so the index digest changes even with an identical
-  # context — measured, not assumed. A re-push would therefore retarget the
-  # release tags, and would be rejected outright once Docker Hub's immutable
-  # tags are enabled for exact versions.
+  # context. A re-push would therefore retarget the release tags, and would be
+  # rejected outright once Docker Hub's immutable tags are enabled for exact
+  # versions.
+  #
+  # Don't try to fix this with SOURCE_DATE_EPOCH — it is deliberate upstream.
+  # moby/buildkit#3421 asked for exactly that and was closed not_planned:
+  # "there is no such thing as reproducible provenance ... the provenance is
+  # for the actual invocation of the build request". A reproducible build is
+  # meant to yield an identical in-toto *subject* (the per-platform image)
+  # while each invocation's provenance legitimately differs — which is what
+  # lets a third party rebuild and sign their own provenance over the same
+  # subject. The index digest sits above both, so it inherits the variance.
   #
   # This job takes only the digest from `build`, so it never pushes an image;
   # it just attaches attestations to what is already published.

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -2,10 +2,11 @@ name: Docker build
 
 # Reusable build + attest path for the container image. The buildx build and
 # the GitHub artifact attestation generation live together in this reusable
-# workflow so the attestations qualify for SLSA Build Level 3: the signed
-# provenance records this workflow file as the signer (its job_workflow_ref),
-# which the calling workflow cannot influence beyond invoking it. Verifiers
-# can require it:
+# workflow — in two jobs, `build` and `attest` — so the attestations qualify
+# for SLSA Build Level 3: the signed provenance records this workflow file as
+# the signer (its job_workflow_ref), which is per-file, not per-job, so the
+# split keeps it intact and the calling workflow still cannot influence it
+# beyond invoking this workflow. Verifiers can require it:
 #
 #   gh attestation verify oci://<image> --repo jkreileder/cf-ips-to-hcloud-fw \
 #     --signer-workflow jkreileder/cf-ips-to-hcloud-fw/.github/workflows/docker-build.yaml
@@ -34,10 +35,12 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write
       security-events: write
       pull-requests: write
-      attestations: write
+
+    # The image digest is the only thing the attest job needs from here.
+    outputs:
+      digest: ${{ steps.build-and-push.outputs.digest }}
 
     steps:
       - name: Harden runner
@@ -128,9 +131,9 @@ jobs:
       # manifest fetches in the verify step below (gh uses the docker
       # keychain), the binfmt/buildkit tooling images, and the base images
       # during the build — ride that embedded token, including on fork PRs and
-      # Dependabot runs. Push credentials are scoped to buildx (below) and a
-      # global login only happens after the build, when unlimited pulls no
-      # longer matter.
+      # Dependabot runs. Push credentials are scoped to buildx (below), and the
+      # unscoped logins that attestation pushes need live in the attest job, on
+      # its own runner, where overwriting the embedded token costs nothing.
 
       # Verify the uv base images carry astral-sh's signed SLSA build provenance
       # before building on them — fail closed, so a PR that repins to an
@@ -281,40 +284,10 @@ jobs:
           cache-from: ${{ !startsWith(github.ref, 'refs/tags/') && 'type=gha' || '' }}
           cache-to: ${{ !startsWith(github.ref, 'refs/tags/') && 'type=gha,mode=max' || '' }}
 
-      # The attest step below and Grype read the default docker config, where
-      # only the runner's embedded pull-only token lives — pushing attestations
-      # to Docker Hub needs a real login. Overwriting the embedded token is
-      # fine now: everything that benefits from its unlimited pulls has run.
-      - name: Login to DockerHub
-        if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Generate artifact attestation for DockerHub
-        if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-name: index.docker.io/${{ vars.DOCKERHUB_USERNAME }}/cf-ips-to-hcloud-fw
-          subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          push-to-registry: true
-
-      - name: Generate artifact attestation for Quay
-        if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-name: quay.io/${{ vars.QUAY_USERNAME }}/cf-ips-to-hcloud-fw
-          subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          push-to-registry: true
-
-      - name: Generate artifact attestation for GitHub Container Registry
-        if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
-        with:
-          subject-name: ghcr.io/${{ github.repository_owner }}/cf-ips-to-hcloud-fw
-          subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          push-to-registry: true
+      # No unscoped `docker login` after the build any more: the attestations
+      # that needed one moved to the attest job below. Grype pulls the freshly
+      # pushed image with the runner's embedded pull token, which is
+      # rate-limit-free, and Scout takes its credentials as inputs (below).
 
       # Scout needs Docker Hub credentials for its API (organization + stream
       # compare), which the embedded pull token doesn't provide. Pass them as
@@ -360,3 +333,103 @@ jobs:
         continue-on-error: true
         with:
           sarif_file: ${{ steps.grype-scan.outputs.sarif }}
+
+  # Attestation runs in its own job so a transient Sigstore/GitHub failure can
+  # be retried with "Re-run failed jobs" without re-running the build. That
+  # matters because a rebuild can never reproduce the pushed digest: buildx
+  # provenance (mode=max) carries a fresh `invocationId` and startedOn/
+  # finishedOn per build, so the index digest changes even with an identical
+  # context — measured, not assumed. A re-push would therefore retarget the
+  # release tags, and would be rejected outright once Docker Hub's immutable
+  # tags are enabled for exact versions.
+  #
+  # This job takes only the digest from `build`, so it never pushes an image;
+  # it just attaches attestations to what is already published.
+  attest:
+    name: Attest
+    needs: build
+    # The event/actor guard mirrors the build job's push guard. The digest
+    # check is what actually has to hold: PR and Dependabot builds use
+    # `load:` instead of `push:`, so there is no pushed digest to attest and
+    # `actions/attest` would fail obscurely on an empty subject-digest.
+    if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && needs.build.outputs.digest != '' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          # Sigstore (fulcio/rekor/timestamp/tuf) for signing, api.github.com
+          # for the attestation store, and the three registries for pushing the
+          # attestation as a referrer of the image digest. No layer pulls
+          # happen here, so the registry CDNs the build job needs are absent.
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            cdn01.quay.io:443
+            cdn02.quay.io:443
+            cdn03.quay.io:443
+            fulcio.sigstore.dev:443
+            ghcr.io:443
+            github.com:443
+            index.docker.io:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+            production.cloudflare.docker.com:443
+            quay.io:443
+            registry-1.docker.io:443
+            rekor.sigstore.dev:443
+            release-assets.githubusercontent.com:443
+            timestamp.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+
+      # Unlike the build job there is nothing here that benefits from the
+      # runner's embedded pull token, so these logins are unscoped.
+      - name: Login to DockerHub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to Quay
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: quay.io
+          username: ${{ vars.QUAY_ROBOT }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate artifact attestation for DockerHub
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: index.docker.io/${{ vars.DOCKERHUB_USERNAME }}/cf-ips-to-hcloud-fw
+          subject-digest: ${{ needs.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for Quay
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: quay.io/${{ vars.QUAY_USERNAME }}/cf-ips-to-hcloud-fw
+          subject-digest: ${{ needs.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation for GitHub Container Registry
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/cf-ips-to-hcloud-fw
+          subject-digest: ${{ needs.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,7 +23,13 @@ jobs:
     # The whole build runs inside the reusable docker-build.yaml so the GitHub
     # artifact attestations qualify for SLSA Build Level 3 (see its header).
     # This job's checks report as "Docker build / <job>"; the default-branch
-    # ruleset's required check references "Docker build / Build".
+    # ruleset's required check references "Docker build / Build". The reusable
+    # workflow also has an "Attest" job, which is skipped on PRs and so is not
+    # a useful required check.
+    #
+    # These permissions are the union the reusable workflow's jobs need — a
+    # caller cannot grant more than it holds — and each job there narrows to
+    # its own subset.
     permissions:
       contents: read
       packages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@
   before it ever reached the attestation step, and a rebuild cannot reproduce
   the digest that was published — buildx provenance (`mode=max`) stamps a fresh
   `invocationId` and start/finish timestamps into every build, so the image
-  index digest differs even from an identical context. The retry therefore
+  index digest differs even from an identical context. That is deliberate
+  upstream rather than a gap `SOURCE_DATE_EPOCH` could close: moby/buildkit#3421
+  requested reproducible provenance and was closed as not planned, since
+  provenance describes one invocation while it is the image it points at that is
+  meant to be reproducible. The retry therefore
   retargeted the release tags to a second image. The attest job consumes only
   the digest the build job outputs, so it can never push an image itself. Both
   jobs still live in the same reusable workflow file, which is what the SLSA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## [v1.4.1] – Unreleased
 
+- Container attestation moved out of the build job into its own `Attest` job in
+  `docker-build.yaml`, so a transient Sigstore or GitHub outage during a release
+  can be retried with "Re-run failed jobs" instead of re-running the build. The
+  old layout made that retry unusable: re-running the job re-executed the push
+  before it ever reached the attestation step, and a rebuild cannot reproduce
+  the digest that was published — buildx provenance (`mode=max`) stamps a fresh
+  `invocationId` and start/finish timestamps into every build, so the image
+  index digest differs even from an identical context. The retry therefore
+  retargeted the release tags to a second image. The attest job consumes only
+  the digest the build job outputs, so it can never push an image itself. Both
+  jobs still live in the same reusable workflow file, which is what the SLSA
+  Build Level 3 `--signer-workflow` check pins, so published verification
+  commands are unchanged
 - Start new development cycle
 
 ## [v1.4.0] – 2026-08-16


### PR DESCRIPTION
## Summary

A transient Sigstore or GitHub outage during a release could not be retried.
"Re-run failed jobs" re-ran the whole `build` job, which re-executed `Build and
push` before it ever reached the attestation steps you were trying to retry.

That re-push is not idempotent, and — importantly — not fixably so. Buildx
provenance (`mode=max`) stamps a fresh `invocationId` and
`startedOn`/`finishedOn` into every build, so the image **index** digest differs
even from an identical build context. Measured on an isolated two-line
Dockerfile, `--no-cache`, `SOURCE_DATE_EPOCH=0`, `rewrite-timestamp=true`, OCI
export:

| Config | Build 1 | Build 2 |
|---|---|---|
| `--provenance=mode=max` | `sha256:80e8505c…` | `sha256:4111148d…` |
| `--provenance=false` | `sha256:b737e2a1…` | `sha256:b737e2a1…` |

This is deliberate upstream, not a gap to wait out. moby/buildkit#3421 asked for
exactly `SOURCE_DATE_EPOCH` support in provenance and was closed `not_planned`:

> there is no such thing as reproducible provenance. If you have a reproducible
> build and you run it three times you get the same artifact (in-toto subject)
> but different provenance metadata. This is because the provenance is for the
> actual invocation of the build request…

So the reproducibility contract is over the *subject* (the per-platform image),
never the attestation describing the invocation — which is precisely what lets a
third party rebuild and sign their own provenance over the same subject. The
index digest sits above both and inherits the variance. A retry therefore
silently retargeted the release tags to a second image, and would be rejected
outright once Docker Hub immutable tags are enabled for exact version tags,
which is the follow-up this unblocks.

Attestation now runs in its own `attest` job that consumes only
`needs.build.outputs.digest`, so it cannot push an image and can be re-run
alone. The job is additionally guarded on `digest != ''` rather than only on the
event, so it is skipped when there is nothing pushed to attest.

**`--signer-workflow` is unaffected.** `job_workflow_ref` is per-file, not
per-job, and both jobs stay in `docker-build.yaml`, so the SLSA Build Level 3
verification commands documented in `README.md` keep working unchanged.

**Least privilege (deliberate, not accidental):** with the attestation steps
gone, `build` no longer declares `id-token: write` or `attestations: write`, and
the unscoped post-build Docker Hub login is removed — it existed only for the
attestation pushes. Grype pulls the published image with the runner's embedded,
rate-limit-free pull token, and Scout takes its credentials as inputs.

The caller's `permissions` block in `docker.yaml` stays as the union of both
jobs' needs, since a caller cannot grant more than it holds.

## Security

No change to token or firewall-rule handling. Registry credentials move to the
new job rather than changing scope; `build` loses two permissions it no longer
uses.

One thing to watch: the new job's `harden-runner` allowlist was assembled by
reasoning about what `actions/attest` does, not verified against a real run, and
`egress-policy: block` turns a miss into a hard failure. The `attest` job is
skipped on PRs, so **the first `main`-branch push after merge is the real
test** — if it trips, the missing host is in that run's harden-runner insights.
That is a strictly better place to discover it than during a tag release.

## Testing

`make check` — 150 passed, 100% coverage (unchanged; no Python touched).
`prek run` on the changed files — actionlint and zizmor both pass, which are the
gates that matter for this diff.

The job-level guard is confirmed on this PR's own run
([31969024399](https://github.com/jkreileder/cf-ips-to-hcloud-fw/actions/runs/31969024399)):
`Docker build / Build: success`, `Docker build / Attest: skipped`.

The two-build digest comparison above was run locally with buildx
0.36.0-desktop.1 (CI pins 0.32.2); `invocationId` is not a version-sensitive
detail, and moby/buildkit#3421 settles it independently of version.