### PR TITLE
docs(release): document retry procedure for immutable tags

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -140,6 +140,44 @@ Pushing the tag starts the publish pipeline. Report the Actions URL:
 > If pushing the tag is also rejected, the tag must be created via a release on
 > the merged commit instead — pause and tell the user; do not force anything.
 
+### 8b. If the publish run fails — retry per job, never re-push
+
+Docker Hub has immutable tags enabled for `^\d+\.\d+\.\d+$`, so once `docker.yaml`
+has pushed `X.Y.Z` that tag can never be overwritten **or deleted**. How you retry
+matters. First find out whether the image was already pushed:
+
+```bash
+run_id="$(gh run list --branch vX.Y.Z --workflow docker.yaml --limit 1 --json databaseId --jq '.[0].databaseId')"
+gh run view "$run_id" --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
+```
+
+- **`Build` failed before/at `Build and push`** — nothing was published. Re-running
+  the whole workflow is safe.
+- **`Build` succeeded and `Attest` failed** (a Sigstore or GitHub blip is the
+  common case) — use **"Re-run failed jobs"**, which re-runs only `Attest`. That
+  job consumes `needs.build.outputs.digest` and never pushes an image, which is
+  exactly why it is a separate job.
+
+  ```bash
+  gh run rerun "$run_id" --failed
+  ```
+
+  Ignore `gh run rerun --help`, which describes `--failed` as "including
+  dependencies" — the REST endpoint it calls re-runs "all of the failed jobs and
+  their **dependent** jobs", i.e. downstream, not upstream. A successful `Build`
+  is not re-run, and `Attest` still reads its `outputs.digest` from that attempt.
+
+- **`Build` failed *after* the push step** — that version is burned. Do not retag,
+  do not delete the tag, do not re-run. Cut the next patch instead.
+
+**Never re-run the whole workflow once the push has happened.** A rebuild cannot
+reproduce the published digest: buildx provenance (`mode=max`) stamps a fresh
+`invocationId` and start/finish timestamps into every build, which is deliberate
+upstream (moby/buildkit#3421, closed not_planned) and not something
+`SOURCE_DATE_EPOCH` can fix. Hub would reject the push outright; Quay and ghcr have
+no immutability and would silently accept it, leaving the three registries
+disagreeing about what `X.Y.Z` is.
+
 ### 9. Publish the draft release
 
 CI creates an empty **draft** GitHub release; the dists are attached after the
@@ -192,6 +230,9 @@ Merge it (use the `ship-changes` skill if helpful).
 - `main` is protected — direct pushes are rejected. Both the release bump and
   the dev-cycle bump go through PRs; only the tag is pushed directly.
 - Never publish PyPI manually — CI owns publishing on tag push.
+- Docker Hub freezes exact version tags (`^\d+\.\d+\.\d+$`); they cannot be
+  overwritten or deleted. A failed publish run is retried with "Re-run failed
+  jobs", never by re-running the build or re-pushing the tag — see step 8b.
 - Tag the **merged** release commit, so the tagged tree's `pyproject.toml`
   version (`X.Y.Z`) matches the tag (`vX.Y.Z`).
 - Branch protection rejects unsigned commits/tags; ensure signing works first.


### PR DESCRIPTION
## Summary

Follow-up to #1459. Docker Hub now has immutable tags enabled for
`^\d+\.\d+\.\d+$`, which changes how a failed release run must be retried — and
that constraint lived only in my head and a workflow comment, not in the runbook
someone actually follows while cutting a release.

Adds step 8b to the `cut-release` skill: how to tell whether the image was
already pushed, and which retry is correct for each failure point.

- `Build` failed before/at the push → nothing published, re-running the whole
  workflow is safe.
- `Build` succeeded, `Attest` failed (the Sigstore-blip case) → `gh run rerun
  --failed`, which re-runs only `Attest`. That job takes only
  `needs.build.outputs.digest` and never pushes an image, which is why #1459
  split it out.
- `Build` failed *after* the push → that version is burned. Cut the next patch;
  don't retag, delete, or re-run.

The reason re-running the whole workflow is never right once the push has
happened: a rebuild cannot reproduce the published digest. Buildx provenance
(`mode=max`) stamps a fresh `invocationId` and start/finish timestamps into every
build — deliberate upstream (moby/buildkit#3421, closed `not_planned`), not
something `SOURCE_DATE_EPOCH` can fix. Hub rejects the push; Quay and ghcr have no
immutability and would silently accept it, leaving the three registries
disagreeing about what `X.Y.Z` is.

One trap documented explicitly: `gh run rerun --help` describes `--failed` as
"including dependencies", which reads as though a successful `Build` would be
re-run too (and re-push). The REST endpoint it calls says "all of the failed jobs
and their **dependent** jobs" — downstream, not upstream. Verified both `gh`
invocations in the new section actually work, including that `gh run list
--branch` accepts a tag ref (`headBranch` is the tag name for tag-triggered runs).

## Security

None directly. Documents an operational constraint that exists to keep published
release tags pinned to the digest they were published with.

## Testing

Documentation only; no code paths touched. `prek run` on the changed file passes
markdownlint. The two `gh` commands were run against this repo: `gh run rerun
--help` confirms the `--failed` flag, and `gh run list --branch v1.4.0 --workflow
docker.yaml` returns the real v1.4.0 run.