### PR TITLE
build(docker): make container images reproducible

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -268,14 +268,37 @@ jobs:
           # the builder itself). Keep the cache for main/PR speed.
           cache-binary: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
+      # Timestamps come from the source commit, not the clock, so rebuilding a
+      # given commit reproduces the same image. Read from the checkout above;
+      # the default fetch-depth of 1 is enough for the tip commit's date.
+      - name: Set SOURCE_DATE_EPOCH from the commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          epoch="$(git log -1 --pretty=%ct)"
+          if ! printf '%s' "$epoch" | grep -Eq '^[0-9]+$'; then
+            echo "::error::Could not read a commit timestamp for SOURCE_DATE_EPOCH"
+            exit 1
+          fi
+          echo "SOURCE_DATE_EPOCH=$epoch" >> "$GITHUB_ENV"
+          echo "SOURCE_DATE_EPOCH=$epoch"
+
       - name: Build and push
         id: build-and-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.SOURCE_DATE_EPOCH }}
         with:
           context: .
           platforms: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'linux/amd64,linux/arm64' || '' }}
-          push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
-          load: ${{ github.event_name == 'pull_request' || github.actor == 'dependabot[bot]' }}
+          # Spelled as `outputs` rather than push/load because rewrite-timestamp
+          # is an image-exporter attribute and the `push` input cannot carry one.
+          # SOURCE_DATE_EPOCH on its own only clamps the config, history and
+          # index timestamps; rewrite-timestamp is what rewrites file mtimes
+          # inside the layers, and without it the image is not reproducible.
+          # `type=docker` is what `load: true` expands to, for the PR/Dependabot
+          # path that builds without pushing.
+          outputs: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'type=image,push=true,rewrite-timestamp=true' || 'type=docker' }}
           sbom: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'generator=docker/scout-sbom-indexer:1.24.0@sha256:4b67f29eb0d1244ab0f62de867ac5dafd7262fcd7ebbdefa6ec8aacd6b15252d' || '' }}
           provenance: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && 'mode=max,version=v1' || '' }}
           tags: ${{ steps.docker-meta.outputs.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## [v1.4.1] – Unreleased
 
+- Container images are now reproducible: rebuilding a given commit yields
+  byte-identical per-platform image manifests. `SOURCE_DATE_EPOCH` is taken from
+  the source commit rather than the clock, and the image exporter runs with
+  `rewrite-timestamp=true` — without the latter only the config, history and
+  index timestamps are pinned, while file mtimes inside the layers still drift.
+  One further source of variance was removed: `uv pip install` writes a
+  `uv_cache.json` into the project's own `.dist-info` containing nothing but a
+  wall-clock install timestamp (every other field is null or empty), and it has
+  no runtime purpose, so it is now deleted along with its `RECORD` line. With
+  that, two consecutive cache-free builds on the pinned BuildKit produce the
+  same manifest digest. The multi-platform *index* digest still differs per
+  build, because buildx provenance deliberately records each invocation
+  (moby/buildkit#3421) — reproducibility is verifiable at the level of the image
+  the attestations point at, which is the in-toto subject
 - Container attestation moved out of the build job into its own `Attest` job in
   `docker-build.yaml`, so a transient Sigstore or GitHub outage during a release
   can be retried with "Re-run failed jobs" instead of re-running the build. The

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,23 @@ RUN --mount=type=bind,from=uv-tools-alpine,source=/usr/local/bin/uv,target=/usr/
     uv sync --link-mode copy --frozen --no-group dev --no-install-project
 
 # Install wheel without dependencies
+#
+# uv pip install writes a uv_cache.json into the installed dist-info holding a
+# wall-clock install timestamp (and otherwise only nulls and empty objects). It
+# has no runtime purpose, and it was the single thing keeping this image from
+# being byte-identical across rebuilds under SOURCE_DATE_EPOCH — every other
+# file in every layer already matches. Drop it, and its RECORD line with it, so
+# RECORD doesn't reference a file that isn't there. Only the project's own
+# dist-info is touched; uv sync's packages never get one.
 RUN --mount=type=bind,from=uv-tools-alpine,source=/usr/local/bin/uv,target=/usr/local/bin/uv \
     --mount=from=builder,target=/dist,source=/usr/src/app/dist \
-    --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
+    --mount=type=cache,id=uv-cache,target=/root/.cache/uv <<EOF
+    set -eux
     uv pip install --link-mode copy --no-compile --force-reinstall --no-deps /dist/*.whl
+    rm -f .venv/lib/python*/site-packages/cf_ips_to_hcloud_fw-*.dist-info/uv_cache.json
+    sed -i '/\.dist-info\/uv_cache\.json,/d' \
+        .venv/lib/python*/site-packages/cf_ips_to_hcloud_fw-*.dist-info/RECORD
+EOF
 
 USER 65534
 


### PR DESCRIPTION
## Summary

Rebuilding a given commit now produces **byte-identical per-platform image
manifests**, so a third party can rebuild a release and confirm it matches the
published image. That is the property `--signer-workflow` attestations are about:
the in-toto *subject* is the image, and per moby/buildkit#3421 the subject is
what reproducible builds make identical, while each invocation's provenance
legitimately differs.

### Measured, before and after

Two `--no-cache` builds of the real image, `linux/arm64`, BuildKit pinned to CI's
exact `v0.32.2` digest, `SOURCE_DATE_EPOCH` fixed, `rewrite-timestamp=true`,
comparing the **image manifest** digest (not the index):

| | Build 1 | Build 2 |
|---|---|---|
| flags only | `sha256:22869382…` | `sha256:e64b4a11…` ❌ |
| flags + this PR | `sha256:51c182e2…` | `sha256:51c182e2…` ✅ |

The flags alone were **not** enough, which is why this PR is more than two config
lines.

### What the diagnosis found

Of nine layers, eight were already bit-identical. The one that differed had an
identical file list and exactly two differing files, both in the project's own
`.dist-info`:

- `uv_cache.json` — contents are `{"timestamp":{"secs_since_epoch":…},"commit":null,"tags":null,"env":{},"directories":{}}`. A wall-clock install timestamp and nothing else.
- `RECORD` — differed only because it hashes that file.

I cleared the obvious suspect first: the wheel is **already** reproducible
(`uv_build` normalises zip entries to 1980-01-01), and `uv_cache.json` is not in
the wheel at all — `uv pip install` writes it, and only for the project's own
dist-info; none of `uv sync`'s packages get one. It has no runtime purpose, so
the install step now deletes it together with its `RECORD` line, so `RECORD`
doesn't reference a file that isn't there.

### Why `outputs` instead of `push`

`rewrite-timestamp` is an image-*exporter* attribute and the `push` input cannot
carry one, so the export is spelled out. `SOURCE_DATE_EPOCH` alone pins only the
config, history and index timestamps — file mtimes inside the layers keep
drifting without it.

This changes where `build-push-action`'s `digest` output comes from, and the
`attest` job consumes it — an empty digest would silently skip attestation via
the `digest != ''` guard. Verified against a throwaway local registry that
`--output type=image,push=true,rewrite-timestamp=true` still populates
`containerimage.digest`. Also confirmed `outputs` is a valid input at the pinned
action SHA.

`type=docker` is exactly what `load: true` expanded to, for the PR/Dependabot
path.

## Security

No change to token or firewall-rule handling. Strengthens the supply-chain story:
a published release can now be independently rebuilt and checked against its
digest, rather than only verified through signatures.

The image loses one file, `uv_cache.json`, which contained only an install
timestamp. The in-image smoke test (`RUN [".venv/bin/cf-ips-to-hcloud-fw",
"--version"]`) passed in every build, and the resulting `.dist-info` is otherwise
intact with a consistent 17-line `RECORD` and no dangling reference.

## Testing

`make check` — 150 passed, 100% coverage. `prek run` on the changed files —
actionlint, zizmor and markdownlint pass.

Four real image builds locally (two before the fix, two after), each `--no-cache`
on the pinned BuildKit; the build itself runs ruff, ty and pytest in the builder
stage, so those gates passed inside every one.

Not verified until this lands on `main`: that CI's multi-arch path behaves the
same as the single-arch local build, and that `type=docker` on the PR path is a
clean swap for `load: true` — this PR's own build exercises the latter.

Deliberately out of scope: `compatibility-version`, which would pin digest-affecting
assembly behaviour across BuildKit *upgrades*. Worth considering separately if
reproducibility should survive a Renovate bump of the BuildKit pin.