### PR TITLE
docs(release): note how to spot-check image reproducibility

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -95,6 +95,42 @@ make build      # rm -rf dist && uv build
 ls dist         # expect a wheel + sdist for the new version
 ```
 
+### 5b. Optional: spot-check image reproducibility
+
+Only worth doing if someone is actually questioning a release, or if the
+Dockerfile or `uv.lock` changed in ways that could reintroduce a timestamp (the
+last offender was a `uv_cache.json` that `uv pip install` wrote into the
+project's `.dist-info`). There is no CI job for this — deliberately, since the
+check costs two cold builds and nothing downstream depends on the property.
+
+Both builds must be cache-free, or the second one just replays the first's
+layers and proves nothing. Expect this to take a while: each build runs ruff, ty
+and pytest inside the builder stage.
+
+```bash
+bk="$(sed -nE 's/.*image=(moby\/buildkit:[^ ]+).*/\1/p' \
+  .github/workflows/docker-build.yaml | head -1)"    # same BuildKit as CI
+docker buildx create --name repro-check --driver docker-container \
+  --driver-opt "image=$bk" --bootstrap
+for i in 1 2; do
+  SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)" docker buildx build \
+    --builder repro-check --no-cache --provenance=false --sbom=false \
+    --output "type=oci,dest=repro-$i.tar,rewrite-timestamp=true" .
+  tar -xOf "repro-$i.tar" index.json | jq -r '.manifests[0].digest'
+done
+docker buildx rm repro-check
+```
+
+The two digests must be identical. If they aren't, diff the layers to find the
+offending file rather than guessing — extract each tar, walk `index.json` →
+manifest → `layers[]`, and compare the layer digests to find which one moved.
+
+Two things this does **not** cover: it builds one native platform, not the
+multi-arch pair, and it exports via `type=oci` rather than CI's
+`type=image,push=true`, so it checks the Dockerfile's determinism rather than
+the export spelling. The multi-platform *index* digest is expected to differ per
+build regardless — buildx provenance records each invocation by design.
+
 ### 6. Open the release PR (the bump cannot go straight to `main`)
 
 `main` is protected, so commit on a branch and open a PR:


### PR DESCRIPTION
## Summary

Images became reproducible in #1461, but nothing guards the property. A CI check
would cost two cold builds — each running ruff, ty and pytest inside the builder
stage — recurring on every uv bump, to protect something no downstream consumer
reads today. If it silently regressed, the concrete consequence is a stale
CHANGELOG sentence: no security hole, no broken deploy. That is out of proportion,
so there is deliberately no CI job.

This records the command instead, as step 5b of the `cut-release` runbook, so the
check exists for the one moment it might matter — someone questioning a release —
and costs nothing the rest of the time.

The snippet reads the BuildKit pin out of `docker-build.yaml` rather than
hardcoding it, so it can't drift from CI when Renovate bumps the builder. It uses
the same measurement that established the property in #1461: cache-free builds,
`SOURCE_DATE_EPOCH` from the commit, `type=oci,…,rewrite-timestamp=true`, compare
`index.json` → `manifests[0].digest`.

Two limits are stated in the runbook rather than left implied: it builds one
native platform, not the multi-arch pair, and it exports via `type=oci` rather
than CI's `type=image,push=true` — so it checks the Dockerfile's determinism, not
the export spelling. It also notes the multi-platform index digest is *expected*
to differ per build, so nobody mistakes that for a regression.

The note points at the last real offender (`uv_cache.json`, written by
`uv pip install`) so a future failure has a starting point, and says to diff the
layers rather than guess.

## Security

None. Documentation only.

## Testing

`prek run` on the changed file — markdownlint passes. The BuildKit pin extraction
was run against the current `docker-build.yaml` and returns
`moby/buildkit:v0.32.2@sha256:28a898…`. The build-and-compare procedure itself is
the one used in #1461, where it produced two differing digests before the fix and
two identical ones after.