### PR TITLE
chore(release): v1.4.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ debug logs).
 
 **Environment**<!-- markdownlint-disable-line MD036 -->
 
-- cf-ips-to-hcloud-fw version: [e.g. 1.4.0]
+- cf-ips-to-hcloud-fw version: [e.g. 1.4.1]
 - Deployment method: [e.g. Docker, Python module]
 - If Python module, Python version: [e.g. 3.14]
 - If Python module, OS: [e.g. macOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.4.1] – Unreleased
+## [v1.4.1] – 2026-08-17
 
 - Container images are now reproducible: rebuilding a given commit yields
   byte-identical per-platform image manifests. `SOURCE_DATE_EPOCH` is taken from
@@ -29,13 +29,12 @@
   upstream rather than a gap `SOURCE_DATE_EPOCH` could close: moby/buildkit#3421
   requested reproducible provenance and was closed as not planned, since
   provenance describes one invocation while it is the image it points at that is
-  meant to be reproducible. The retry therefore
-  retargeted the release tags to a second image. The attest job consumes only
-  the digest the build job outputs, so it can never push an image itself. Both
+  meant to be reproducible. The retry would therefore have retargeted the release
+  tags to a second image. The attest job consumes only the digest the build job
+  outputs, so it can never push an image itself. Both
   jobs still live in the same reusable workflow file, which is what the SLSA
   Build Level 3 `--signer-workflow` check pins, so published verification
   commands are unchanged
-- Start new development cycle
 
 ## [v1.4.0] – 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.4.0
+  jkreileder/cf-ips-to-hcloud-fw:1.4.1
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -161,7 +161,7 @@ command override is needed:
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
   -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
-  jkreileder/cf-ips-to-hcloud-fw:1.4.0
+  jkreileder/cf-ips-to-hcloud-fw:1.4.1
 ```
 
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
@@ -169,7 +169,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.4`: This tag always points to the latest `1.4.x` release.
-- `1.4.0`: This tag points to the specific `1.4.0` release.
+- `1.4.1`: This tag points to the specific `1.4.1` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -221,7 +221,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.4.0
+              image: jkreileder/cf-ips-to-hcloud-fw:1.4.1
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false
@@ -248,7 +248,7 @@ falls back to these variables:
 ```yaml
 containers:
   - name: cf-ips-to-hcloud-fw
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.0
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.1
     env:
       - name: HCLOUD_TOKEN
         valueFrom:
@@ -451,7 +451,7 @@ service that uses the image's default one-shot entrypoint:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.0
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.1
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
 ```
@@ -471,7 +471,7 @@ the `docker compose run` line above, or the override makes the run never exit:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.0
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.1
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
     # Re-run every 24h (86400s) inside one container instead of a scheduler.
@@ -518,7 +518,7 @@ with the `gh attestation verify --bundle` command shown below.
 
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.4.0
+VERSION=1.4.1
 
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
@@ -570,7 +570,7 @@ Build provenance:
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
 IMAGE_REPO=docker.io/jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.4.0
+VERSION=1.4.1
 IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 
 # Verifying build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.4.1.dev1"
+version = "1.4.1"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.4.1.dev1"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Release v1.4.1. Bumps `pyproject.toml` (and the project version in `uv.lock`) to
`1.4.1`, dates the CHANGELOG entry, and bumps the pinned image tag in `README.md`
and the example version in the bug report template.

The release itself is CI/supply-chain work — no runtime behaviour changes:

- Container images are reproducible: `SOURCE_DATE_EPOCH` comes from the source
  commit and the image exporter runs with `rewrite-timestamp=true`. The
  `uv_cache.json` that `uv pip install` wrote into the project's `.dist-info`
  (a wall-clock timestamp with no runtime purpose) is removed along with its
  `RECORD` line — it was the last source of variance.
- Container attestation moved into its own `Attest` job, so a transient Sigstore
  or GitHub outage during a release is retried with "Re-run failed jobs" rather
  than re-running the build. It consumes only the build job's digest output, so
  it can never push an image. Both jobs stay in the same reusable workflow file,
  which is what `--signer-workflow` pins, so published verification commands are
  unchanged.

Two CHANGELOG fixes ride along: a garbled sentence in the attestation bullet, and
the `Start new development cycle` bullet (dropped at release time, as in prior
releases).

Tagging `v1.4.1` on the merge commit is what starts the publish pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker, Kubernetes, Docker Compose, and attestation examples to reference version 1.4.1.
  * Clarified attestation retry behavior and verification instructions.
  * Marked version 1.4.1 as released with its release date.
  * Updated the bug report template’s example version.

* **Release**
  * Promoted the project from development version 1.4.1.dev1 to stable version 1.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->