### PR TITLE
chore: start new development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- markdownlint-disable MD024 -->
 
+## [v1.4.2] – Unreleased
+
+- Start new development cycle
+
 ## [v1.4.1] – 2026-08-17
 
 - Container images are now reproducible: rebuilding a given commit yields

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.4.1"
+version = "1.4.2.dev1"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.4.1"
+version = "1.4.2.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Begin v1.4.2 development. Bumps `pyproject.toml` (and the project version in
`uv.lock`) to `1.4.2.dev1` and opens a fresh `## [v1.4.2] – Unreleased` section
in the CHANGELOG.

Follows the v1.4.1 release (#1464, tag `v1.4.1`).