### PR TITLE
fix(docker): apk upgrade the final stage so Alpine security fixes don't wait for a base rebuild

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -143,6 +143,11 @@ multi-arch pair, and it exports via `type=oci` rather than CI's
 the export spelling. The multi-platform *index* digest is expected to differ per
 build regardless — buildx provenance records each invocation by design.
 
+The `apk upgrade` in the final stage is the one input outside the pinned
+digests: two builds match only if Alpine's package repo did not move between
+them. If the digests differ, diff the two images' `apk list -I` output before
+suspecting a timestamp.
+
 ### 6. Open the release PR (the bump cannot go straight to `main`)
 
 `main` is protected, so commit on a branch and open a PR:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -307,6 +307,12 @@ jobs:
           annotations: ${{ steps.docker-meta.outputs.annotations }}
           cache-from: ${{ !startsWith(github.ref, 'refs/tags/') && 'type=gha' || '' }}
           cache-to: ${{ !startsWith(github.ref, 'refs/tags/') && 'type=gha,mode=max' || '' }}
+          # The gha cache keys a layer on its instruction and parent chain, so
+          # the final stage's `apk upgrade` would replay from cache long after
+          # Alpine moved on, and the `:main` image would ship stale packages.
+          # Rebuild that stage every time; the builder stage (lint, tests,
+          # wheel) stays cached. Tag builds run cache-free regardless.
+          no-cache-filters: ${{ !startsWith(github.ref, 'refs/tags/') && 'final-image' || '' }}
 
       # No unscoped `docker login` after the build any more: the attestations
       # that needed one moved to the attest job below. Grype pulls the freshly

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -66,6 +66,7 @@ jobs:
             cdn03.quay.io:443
             d2glxqk2uabbnd.cloudfront.net:443
             d5l0dvt14r5h8.cloudfront.net:443
+            dl-cdn.alpinelinux.org:443
             docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com:443
             files.pythonhosted.org:443
             fulcio.sigstore.dev:443

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [v1.4.2] – Unreleased
 
+- The container image now runs `apk upgrade` in its final stage, so security
+  fixes that Alpine has already published reach the image without waiting for
+  the next rebuild of the official `python:*-alpine` base. The base image is
+  rebuilt only on CPython and Alpine point releases, which left the published
+  image with a `libssl3`/`libcrypto3` that Alpine had already patched. This
+  adds one input outside the digest-pinned set (Alpine's package repo; apk
+  still verifies package signatures), so a rebuild of a given commit is
+  byte-identical only while that repo has not moved in between
 - Start new development cycle
 
 ## [v1.4.1] – 2026-08-17

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,14 @@ RUN rm -rf /usr/local/lib/python3.*/site-packages/pip \
            /usr/local/lib/python3.*/site-packages/pip-*.dist-info \
            /usr/local/bin/pip*
 
+# The official python image is rebuilt only on CPython and Alpine point
+# releases, while Alpine's security repo moves between them. Pull in whatever
+# package updates the repo has so a fixed CVE in the base (openssl, musl,
+# busybox, ...) never waits for the next upstream rebuild. This is the one
+# build input that isn't digest-pinned; apk still verifies every package
+# against the Alpine signing keys shipped in the base image.
+RUN apk upgrade --no-cache
+
 # Resolve and install dependencies
 RUN --mount=type=bind,from=uv-tools-alpine,source=/usr/local/bin/uv,target=/usr/local/bin/uv \
     --mount=target=pyproject.toml,source=/pyproject.toml \


### PR DESCRIPTION
## Summary

The daily rescan (run 33093454177) fails on ten fixable openssl CVEs in the published image: `python:3.14.7-alpine3.24` ships `libssl3`/`libcrypto3` 3.5.7-r0, while Alpine's v3.24 repo already has 3.5.8-r0. The official image is rebuilt only on CPython and Alpine point releases; the next guaranteed one is CPython 3.14.8 on 2026-10-06.

This adds `RUN apk upgrade --no-cache` to the final stage so published Alpine security fixes reach the image without waiting for the upstream rebuild — for openssl now, and for musl/busybox/zlib next time. The build job's harden-runner allowlist gains `dl-cdn.alpinelinux.org:443` so the fetch isn't blocked; this PR's own build exercises that path.

Switching to a plain `alpine` base with a uv-managed interpreter was considered and rejected: `alpine:3.24` (built 2026-06-16) carries the same 3.5.7-r0, so it inherits the problem, and python-build-standalone's statically linked OpenSSL is invisible to `only-fixed` scanning rather than fixed.

Trade-off: Alpine's package repo becomes the one build input outside the digest-pinned set. apk still verifies package signatures, so integrity is unchanged; rebuilding a commit is byte-identical only while the repo hasn't moved in between. The release skill's reproducibility spot-check and the changelog note this.

The rescan stays red until this is released: it scans the published `:1` tag, and Hub tags are immutable, so a v1.4.2 patch release follows this merge.

## Security

No token, secret, or firewall-rule impact. Removes ten fixable openssl CVEs (7 high, 1 medium, 2 unrated) from the container image's TLS client.

## Testing

- Full local build of the Dockerfile (ruff, ty, pytest run in the builder stage): passes; `apk list -I` in the result shows `libssl3`/`libcrypto3` 3.5.8-r0.
- `grype --only-fixed --fail-on medium --add-cpes-if-none -c .grype.yaml` on the built image (CI's flags): `No vulnerabilities found`.
- Control: the same scan against `alpine:3.24` + `uv python install 3.14.7` reproduces all ten CVEs.
- `make check` — 150 passed, 100% coverage; pre-commit hooks (markdownlint, actionlint, zizmor) pass on the changed files.

https://claude.ai/code/session_01LihRrGfvS7onZDGpoayeaX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Maintenance**
  * Alpine packages in the final Docker image are now upgraded during the build, incorporating available security updates.

* **Documentation**
  * Added unreleased v1.4.2 changelog notes describing package upgrades and their reproducibility impact.
  * Updated build troubleshooting guidance to account for changing Alpine package repositories and installed package lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->