### PR TITLE
chore(release): v1.4.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ debug logs).
 
 **Environment**<!-- markdownlint-disable-line MD036 -->
 
-- cf-ips-to-hcloud-fw version: [e.g. 1.4.1]
+- cf-ips-to-hcloud-fw version: [e.g. 1.4.2]
 - Deployment method: [e.g. Docker, Python module]
 - If Python module, Python version: [e.g. 3.14]
 - If Python module, OS: [e.g. macOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,18 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.4.2] – Unreleased
+## [v1.4.2] – 2026-08-27
 
-- The container image now runs `apk upgrade` in its final stage, so security
-  fixes that Alpine has already published reach the image without waiting for
-  the next rebuild of the official `python:*-alpine` base. The base image is
-  rebuilt only on CPython and Alpine point releases, which left the published
-  image with a `libssl3`/`libcrypto3` that Alpine had already patched. This
-  adds one input outside the digest-pinned set (Alpine's package repo; apk
-  still verifies package signatures), so a rebuild of a given commit is
-  byte-identical only while that repo has not moved in between
-- Start new development cycle
+- **Security:** The container image now runs `apk upgrade` in its final stage, so Alpine
+  security fixes reach the image without waiting for the next rebuild of the official
+  `python:*-alpine` base. That base is rebuilt only on CPython and Alpine point releases,
+  which had left the published image with a `libssl3`/`libcrypto3` Alpine had already
+  patched — ten fixable CVEs, seven of them high. The upgrade covers the whole base going
+  forward, not just openssl. It adds one build input outside the digest-pinned set
+  (Alpine's package repo; apk still verifies package signatures), so rebuilding a given
+  commit is byte-identical only while that repo has not moved in between. Release builds
+  were already cache-free; `main` and pull-request builds now exclude the final stage from
+  the layer cache, so the upgrade cannot replay a stale layer
 
 ## [v1.4.1] – 2026-08-17
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.4.1
+  jkreileder/cf-ips-to-hcloud-fw:1.4.2
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -161,7 +161,7 @@ command override is needed:
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
   -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
-  jkreileder/cf-ips-to-hcloud-fw:1.4.1
+  jkreileder/cf-ips-to-hcloud-fw:1.4.2
 ```
 
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
@@ -169,7 +169,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.4`: This tag always points to the latest `1.4.x` release.
-- `1.4.1`: This tag points to the specific `1.4.1` release.
+- `1.4.2`: This tag points to the specific `1.4.2` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -221,7 +221,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.4.1
+              image: jkreileder/cf-ips-to-hcloud-fw:1.4.2
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false
@@ -248,7 +248,7 @@ falls back to these variables:
 ```yaml
 containers:
   - name: cf-ips-to-hcloud-fw
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.1
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.2
     env:
       - name: HCLOUD_TOKEN
         valueFrom:
@@ -451,7 +451,7 @@ service that uses the image's default one-shot entrypoint:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.1
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.2
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
 ```
@@ -471,7 +471,7 @@ the `docker compose run` line above, or the override makes the run never exit:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.1
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.2
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
     # Re-run every 24h (86400s) inside one container instead of a scheduler.
@@ -518,7 +518,7 @@ with the `gh attestation verify --bundle` command shown below.
 
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.4.1
+VERSION=1.4.2
 
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
@@ -570,7 +570,7 @@ Build provenance:
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
 IMAGE_REPO=docker.io/jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.4.1
+VERSION=1.4.2
 IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 
 # Verifying build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.4.2.dev1"
+version = "1.4.2"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.4.2.dev1"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
## Summary

Release v1.4.2. Bumps the version, refreshes `uv.lock`, dates the changelog entry, and updates the pinned image tag in `README.md` and the bug-report template.

The release itself is the container hardening from #1467: the final stage runs `apk upgrade`, so Alpine security fixes no longer wait for the official `python:*-alpine` base to be rebuilt. This clears ten fixable openssl CVEs (7 high, 1 medium, 2 unrated) that the daily rescan has been failing on — the rescan scans the published `:1` tag, and Hub tags are immutable, so it stays red until this release re-points it.

## Security

No token, secret, or firewall-rule impact. Removes the ten fixable openssl CVEs listed above from the published image.

## Testing

`make lint`, `make test` (150 passed, 100% coverage) and `make build` (wheel + sdist for 1.4.2) all pass locally.

https://claude.ai/code/session_01LihRrGfvS7onZDGpoayeaX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Released version 1.4.2 on August 27, 2026.
  - Updated Docker, Kubernetes, Docker Compose, Python package, and image verification examples to version 1.4.2.

- **Security**
  - Documented updated base packages, OpenSSL security fixes, CVE counts, and reproducible package-build constraints.

- **Documentation**
  - Updated bug report examples and release references throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->