### PR TITLE
chore: start new development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- markdownlint-disable MD024 -->
 
+## [v1.4.3] – Unreleased
+
+- Start new development cycle
+
 ## [v1.4.2] – 2026-08-27
 
 - **Security:** The container image now runs `apk upgrade` in its final stage, so Alpine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.4.2"
+version = "1.4.3.dev1"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.4.2"
+version = "1.4.3.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
## Summary

Begin v1.4.3 development: bumps `pyproject.toml` to `1.4.3.dev1`, refreshes `uv.lock`, and opens a fresh `## [v1.4.3] – Unreleased` changelog section.

## Security

None.

## Testing

`uv lock` refreshed; the version bump is covered by the `Check release version` workflow.

https://claude.ai/code/session_01LihRrGfvS7onZDGpoayeaX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an unreleased changelog entry for version 1.4.3.
* **Chores**
  * Updated the project version to 1.4.3 development release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->