### PR TITLE
ci: adopt the self-repository uses syntax for in-repo reusable workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,14 @@
+# GitHub's self-repository `uses:` form (`$/...`) resolves to the caller's own
+# commit without a checkout, and counts as pinning under the "require actions
+# pinned to a SHA" policy, which the workspace-relative `./...` form does not.
+# actionlint does not recognize the syntax yet (rhysd/actionlint#711), so it
+# reports a format error for every such reference.
+#
+# The two patterns match only `$/`-prefixed refs: a ref that is malformed for
+# any other reason is still reported. Delete this file once actionlint accepts
+# the syntax.
+paths:
+  .github/workflows/**/*.{yaml,yml}:
+    ignore:
+      - reusable workflow call "\$/.+" at "uses" is not following the format
+      - specifying action "\$/.+" in invalid format because ref is missing

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,7 +37,7 @@ jobs:
       security-events: write
       pull-requests: write
       attestations: write
-    uses: ./.github/workflows/docker-build.yaml
+    uses: $/.github/workflows/docker-build.yaml
     secrets:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -56,12 +56,13 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }} and install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1 # zizmor: ignore[cache-poisoning]
         with:
           python-version: ${{ matrix.python-version }}
           version: "0.12.5"
           # No cache restore on tag runs so the release path can't be tainted
-          # by a poisoned cache (cache-poisoning audit).
+          # by a poisoned cache (cache-poisoning audit). zizmor cannot evaluate
+          # the expression, hence the ignore on the step.
           enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       # Scan the locked deps against OSV's malware advisories on every PR/push
@@ -307,7 +308,7 @@ jobs:
       contents: read
       id-token: write
       attestations: write
-    uses: ./.github/workflows/build-and-attest-dist.yaml
+    uses: $/.github/workflows/build-and-attest-dist.yaml
 
   draft-release:
     name: Create draft release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
       # YAML/expression checks otherwise.
       - id: actionlint
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: 451b56af716f9f0d0c2b816503a3fd0cf8b036fa  # frozen: v1.29.0
+    rev: cef8b8350da46d8114c7e6b7272aebdccdf193ce  # frozen: v1.30.0
     hooks:
       # Security audit of GitHub Actions workflows (template injection,
       # credential persistence, cache poisoning, ...); complements actionlint,


### PR DESCRIPTION
## Summary

Bumps the zizmor pre-commit hook to v1.30.0 and resolves the three findings the
new version surfaces. Baseline at v1.29.0 was clean, verified by stashing the
bump and re-running.

**New `self-repository` audit** — flags both job-level calls into in-repo
reusable workflows:

```
help[self-repository]: use GitHub's dedicated self-repository syntax
   --> .github/workflows/docker.yaml:40:11
    |
 40 |     uses: ./.github/workflows/docker-build.yaml
    |           ^^^ use '$/...' instead of './...'
```

The `$/` form resolves to the caller's own commit without a checkout, and counts
as pinning under the *require actions pinned to a SHA* policy this repository has
enabled — which `./` does not. It
[shipped for github.com on 2026-07-30](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)
and covers job-level reusable workflow calls.

**Why the extra config file** — actionlint rejects the syntax outright:

```
docker.yaml:40:11: reusable workflow call "$/.github/workflows/docker-build.yaml"
at "uses" is not following the format ... [workflow-call]
```

Support is requested as [rhysd/actionlint#711](https://github.com/rhysd/actionlint/issues/711),
filed the day the feature shipped and untouched since, with no PR behind it. The
latest release (v1.7.12) predates the syntax and `main` has had no commits since
April, so waiting it out is not a short wait. Both linters gate pre-commit and
CI, so one has to stand down.

Scoping actionlint costs less than suppressing the audit. The two patterns in the
new `.github/actionlint.yaml` match **only** `$/`-prefixed refs, so this does not
blind the format check generally. The alternative — an inline
`# zizmor: ignore[self-repository]` — would have left the finding suppressed
rather than fixed. Delete the file once actionlint accepts the syntax.

**Widened `cache-poisoning` audit** — v1.30.0 also flags the `setup-uv` step in
`python-package.yaml`. The mitigation it asks for is already in place —
`enable-cache: ${{ !startsWith(github.ref, 'refs/tags/') }}` keeps the release
path off the cache — but zizmor cannot evaluate the expression (confidence: Low),
so the step carries an inline ignore, matching the existing idiom at
`docker-build.yaml:263`.

## Security

No token, secret, or firewall-rule impact. Net positive on the workflow side: the
two reusable-workflow calls now satisfy the SHA-pinning policy rather than being
exempt from it.

Both forms resolve to the same commit, so the workflow file named by the Sigstore
certificate is unchanged and the `--signer-workflow` arguments documented in the
README still apply. Worth an eye on the first tagged release, since nothing
exercises the attestation path until then — the two call sites are non-PR paths,
so the syntax and its interaction with the pinning policy get their first real
run on the merge to `main`.

## Testing

`SKIP=ruff-check,ruff-format,ty,uv-lock prek run --all-files`: 12/12 green.
`make check`: 150 passed, 100% coverage.

Negative controls, since a test that passes either way proves nothing:

| Control | Result |
| --- | --- |
| Remove `.github/actionlint.yaml` | Both `$/` refs fail again — the config is what does the work |
| Lint a throwaway workflow with a bad action ref *and* a bad reusable-workflow ref, config in place | Both still reported — the ignore is narrow |
| Remove the `zizmor: ignore` | `cache-poisoning` returns, and only that finding — the ignore does the work |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved workflow validation for reusable GitHub Actions references.
  - Updated CI security scanning configuration and added guidance for approved cache behavior.
  - Updated the pre-commit security tool to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->