### PR TITLE
chore(release): v1.4.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ debug logs).
 
 **Environment**<!-- markdownlint-disable-line MD036 -->
 
-- cf-ips-to-hcloud-fw version: [e.g. 1.4.2]
+- cf-ips-to-hcloud-fw version: [e.g. 1.4.3]
 - Deployment method: [e.g. Docker, Python module]
 - If Python module, Python version: [e.g. 3.14]
 - If Python module, OS: [e.g. macOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.4.3] – Unreleased
+## [v1.4.3] – 2026-09-05
 
-- Start new development cycle
+- **Security:** The container image now ships Alpine's `util-linux` 2.42.3-r0, fixing four
+  high-severity CVEs in the `libuuid` it installs — CVE-2026-76642, CVE-2026-78408,
+  CVE-2026-78409 and CVE-2026-78410. The v1.4.2 image was built against 2.42.1-r0
+- Updated the Cloudflare SDK to 5.7.0, Pydantic to 2.13.5 and anyio to 4.15.0, and refreshed the
+  pinned base images (`python:3.14.7-alpine3.24`, `python:3.14.7-trixie`, `astral/uv` 0.12.10)
+  and the Dockerfile frontend to 1.27.0
 
 ## [v1.4.2] – 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.4.2
+  jkreileder/cf-ips-to-hcloud-fw:1.4.3
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -161,7 +161,7 @@ command override is needed:
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
   -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
-  jkreileder/cf-ips-to-hcloud-fw:1.4.2
+  jkreileder/cf-ips-to-hcloud-fw:1.4.3
 ```
 
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
@@ -169,7 +169,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.4`: This tag always points to the latest `1.4.x` release.
-- `1.4.2`: This tag points to the specific `1.4.2` release.
+- `1.4.3`: This tag points to the specific `1.4.3` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -221,7 +221,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.4.2
+              image: jkreileder/cf-ips-to-hcloud-fw:1.4.3
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false
@@ -248,7 +248,7 @@ falls back to these variables:
 ```yaml
 containers:
   - name: cf-ips-to-hcloud-fw
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.2
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.3
     env:
       - name: HCLOUD_TOKEN
         valueFrom:
@@ -451,7 +451,7 @@ service that uses the image's default one-shot entrypoint:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.2
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.3
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
 ```
@@ -471,7 +471,7 @@ the `docker compose run` line above, or the override makes the run never exit:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.2
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.3
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
     # Re-run every 24h (86400s) inside one container instead of a scheduler.
@@ -518,7 +518,7 @@ with the `gh attestation verify --bundle` command shown below.
 
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.4.2
+VERSION=1.4.3
 
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
@@ -570,7 +570,7 @@ Build provenance:
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
 IMAGE_REPO=docker.io/jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.4.2
+VERSION=1.4.3
 IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 
 # Verifying build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.4.3.dev1"
+version = "1.4.3"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.4.3.dev1"
+version = "1.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Release v1.4.3.

Rebuilds the container image against Alpine's `util-linux` 2.42.3-r0, which fixes four
high-severity CVEs (CVE-2026-76642, CVE-2026-78408, CVE-2026-78409, CVE-2026-78410) in the
`libuuid` the image installs. The x86_64 package landed in `v3.24/main` earlier today; until
then only arm64 could pick it up, so the fix reaches both architectures with this build.

Also finalizes the changelog and bumps the pinned version in `README.md` and the bug-report
template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation, deployment, and verification examples to use version 1.4.3.
  * Updated the bug report template’s example version to 1.4.3.
  * Added release notes for version 1.4.3, including security-related dependency updates.

* **Release**
  * Published version 1.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->