### PR TITLE
chore: start new development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- markdownlint-disable MD024 -->
 
+## [v1.4.4] – Unreleased
+
+- Start new development cycle
+
 ## [v1.4.3] – 2026-09-05
 
 - **Security:** The container image now ships Alpine's `util-linux` 2.42.3-r0, fixing four

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.4.3"
+version = "1.4.4.dev1"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.4.3"
+version = "1.4.4.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Begin v1.4.4 development: bumps the version to `1.4.4.dev1`, refreshes `uv.lock`, and opens a fresh changelog section.