### PR TITLE
chore(release): v1.4.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ debug logs).
 
 **Environment**<!-- markdownlint-disable-line MD036 -->
 
-- cf-ips-to-hcloud-fw version: [e.g. 1.4.3]
+- cf-ips-to-hcloud-fw version: [e.g. 1.4.4]
 - Deployment method: [e.g. Docker, Python module]
 - If Python module, Python version: [e.g. 3.14]
 - If Python module, OS: [e.g. macOS 15.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 <!-- markdownlint-disable MD024 -->
 
-## [v1.4.4] – Unreleased
+## [v1.4.4] – 2026-09-06
 
-- Start new development cycle
+- **Security:** The container image now ships Alpine's `util-linux` 2.42.3-r1. Alpine reassigned
+  CVE-2026-78408 from 2.42.3-r0 to 2.42.3-r1 after the v1.4.3 image was built, so the v1.4.3
+  image still reports that one high-severity CVE in `libuuid`
 
 ## [v1.4.3] – 2026-09-05
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Here's an example using Docker:
 ```shell
 docker run --rm \
   --mount type=bind,source=$(pwd)/config.yaml,target=/usr/src/app/config.yaml,readonly \
-  jkreileder/cf-ips-to-hcloud-fw:1.4.3
+  jkreileder/cf-ips-to-hcloud-fw:1.4.4
 ```
 
 (Add `--pull=always` if you use a rolling image tag.)
@@ -161,7 +161,7 @@ command override is needed:
 docker run --rm \
   -e HCLOUD_TOKEN=your-api-token \
   -e HCLOUD_FIREWALLS=$'firewall-1\nfirewall-2' \
-  jkreileder/cf-ips-to-hcloud-fw:1.4.3
+  jkreileder/cf-ips-to-hcloud-fw:1.4.4
 ```
 
 Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
@@ -169,7 +169,7 @@ Docker images for `cf-ips-to-hcloud-fw` are available for both `linux/amd64` and
 
 - `1`: This tag always points to the latest `1.x.x` release.
 - `1.4`: This tag always points to the latest `1.4.x` release.
-- `1.4.3`: This tag points to the specific `1.4.3` release.
+- `1.4.4`: This tag points to the specific `1.4.4` release.
 - `main`: This tag points to the most recent development version of
   `cf-ips-to-hcloud-fw`. Use this at your own risk as it may contain unstable
   changes.
@@ -221,7 +221,7 @@ spec:
             runAsUser: 65534
           containers:
             - name: cf-ips-to-hcloud-fw
-              image: jkreileder/cf-ips-to-hcloud-fw:1.4.3
+              image: jkreileder/cf-ips-to-hcloud-fw:1.4.4
               # imagePullPolicy: Always # Uncomment this if you use a rolling image tag
               securityContext:
                 allowPrivilegeEscalation: false
@@ -248,7 +248,7 @@ falls back to these variables:
 ```yaml
 containers:
   - name: cf-ips-to-hcloud-fw
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.3
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.4
     env:
       - name: HCLOUD_TOKEN
         valueFrom:
@@ -451,7 +451,7 @@ service that uses the image's default one-shot entrypoint:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.3
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.4
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
 ```
@@ -471,7 +471,7 @@ the `docker compose run` line above, or the override makes the run never exit:
 ```yaml
 services:
   cf-ips-to-hcloud-fw:
-    image: jkreileder/cf-ips-to-hcloud-fw:1.4.3
+    image: jkreileder/cf-ips-to-hcloud-fw:1.4.4
     volumes:
       - ./config.yaml:/usr/src/app/config.yaml
     # Re-run every 24h (86400s) inside one container instead of a scheduler.
@@ -518,7 +518,7 @@ with the `gh attestation verify --bundle` command shown below.
 
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.4.3
+VERSION=1.4.4
 
 # Verifying build provenance
 gh attestation verify cf_ips_to_hcloud_fw-$VERSION-py3-none-any.whl \
@@ -570,7 +570,7 @@ Build provenance:
 ```shell
 GH_REPO=jkreileder/cf-ips-to-hcloud-fw
 IMAGE_REPO=docker.io/jkreileder/cf-ips-to-hcloud-fw
-VERSION=1.4.3
+VERSION=1.4.4
 IMAGE=$IMAGE_REPO@$(crane digest $IMAGE_REPO:$VERSION)
 
 # Verifying build provenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
-version = "1.4.4.dev1"
+version = "1.4.4"
 dependencies = [
     "cloudflare>=5.6.0",
     "hcloud>=2.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "cf-ips-to-hcloud-fw"
-version = "1.4.4.dev1"
+version = "1.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "cloudflare" },


### PR DESCRIPTION
Release v1.4.4. Bumps version and finalizes the changelog.

Alpine reassigned CVE-2026-78408 from `util-linux` 2.42.3-r0 to 2.42.3-r1 after the v1.4.3 image
was built, so the released image reports that one CVE again (rescan run 34024572804). Rebuilding
picks up r1, which is now published for both x86_64 and aarch64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Finalized version 1.4.4 and published its dated changelog entry.
  * Updated documented Docker, Kubernetes, Compose, Python package, and image verification references to 1.4.4.

* **Security**
  * The 1.4.4 container image includes Alpine’s updated `util-linux` package, addressing the reported CVE status for `libuuid`.

* **Documentation**
  * Updated the bug report template’s example version to 1.4.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->