### PR TITLE
ci(grype): ignore three more CPython CVEs fixed only in 3.15.0rc2

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -5,7 +5,7 @@
 #
 # CPython CVEs matched against the interpreter binary in the
 # python:3.14.x-alpine base image. Grype lists them as "fixed" only in the
-# 3.15 stream (3.15.0a6/b3/b4/3.15.0); the 3.14-branch backports are merged
+# 3.15 stream (3.15.0a6/b3/b4/rc2/3.15.0); the 3.14-branch backports are merged
 # upstream but unreleased, so no base-image bump can clear them yet and
 # only-fixed does not filter them.
 # REMOVE when the Dockerfile base image reaches python >= 3.14.8 (expected to
@@ -37,6 +37,18 @@ ignore:
       name: python
       type: binary
   - vulnerability: CVE-2025-15367
+    package:
+      name: python
+      type: binary
+  - vulnerability: CVE-2026-15310
+    package:
+      name: python
+      type: binary
+  - vulnerability: CVE-2026-15806
+    package:
+      name: python
+      type: binary
+  - vulnerability: CVE-2026-17084
     package:
       name: python
       type: binary


### PR DESCRIPTION
## Summary
The daily rescan has failed since 2026-09-10 on three new CPython CVEs matched against the
interpreter binary in the `python:3.14.7-alpine` base:

| CVE | Severity | Grype fix version |
| --- | --- | --- |
| CVE-2026-17084 | medium | 3.15.0rc2 |
| CVE-2026-15806 | medium | 3.15.0rc2 |
| CVE-2026-15310 | low | 3.15.0rc2 |

Same situation as the seven existing entries: the fix exists only in the 3.15 stream, so no
3.14 base-image bump can clear them and `--only-fixed` does not filter them. This adds the three
to `.grype.yaml` under the existing removal condition (drop once the base reaches python >= 3.14.8),
tracked in #1412.

## Security
None. Ignore rules are scoped to the `python` binary package only; nothing about tokens,
secrets, or firewall rules changes.

## Testing
Ran the rescan workflow's Grype command line locally (grype 0.118.0, DB v6.1.9) against
`docker.io/jkreileder/cf-ips-to-hcloud-fw:1`: with an empty ignore list it reports exactly these
three CVEs; with this `.grype.yaml` it reports no vulnerabilities and exits 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanning configuration to account for three additional Python binary CVEs.
  * Clarified the listed CPython 3.15 release versions in the scanner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->